### PR TITLE
fix: fall back when detected source equals default translate target

### DIFF
--- a/src/browser-extension/content_script/InlineLookupContainer.tsx
+++ b/src/browser-extension/content_script/InlineLookupContainer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { detectLang, LangCode } from '@/common/lang'
+import { detectLang, pickTranslateAutoTargetLang } from '@/common/lang'
 import { translate } from '@/common/translate'
 import { useSettings } from '@/common/hooks/useSettings'
 import { actionService } from '@/common/services/action'
@@ -28,10 +28,11 @@ export function InlineLookupContainer({ text, onClose }: InlineLookupContainerPr
 
             try {
                 const sourceLang = await detectLang(text)
-                const targetLang: LangCode =
-                    sourceLang === 'zh-Hans' || sourceLang === 'zh-Hant'
-                        ? 'en'
-                        : (settings.defaultTargetLanguage as LangCode | undefined) ?? 'en'
+                const targetLang = pickTranslateAutoTargetLang(
+                    sourceLang,
+                    settings.defaultTargetLanguage,
+                    settings.writingTargetLanguage
+                )
 
                 let action: Action | undefined
                 try {
@@ -80,7 +81,7 @@ export function InlineLookupContainer({ text, onClose }: InlineLookupContainerPr
                 setIsLoading(false)
             }
         },
-        [settings.defaultTargetLanguage]
+        [settings.defaultTargetLanguage, settings.writingTargetLanguage]
     )
 
     useEffect(() => {

--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -13,7 +13,14 @@ import { TbArrowsExchange, TbCsv } from 'react-icons/tb'
 import { MdOutlineGrade, MdGrade, MdHistory } from 'react-icons/md'
 import * as mdIcons from 'react-icons/md'
 import { StatefulTooltip } from 'baseui-sd/tooltip'
-import { detectLang, getLangConfig, sourceLanguages, targetLanguages, LangCode } from '../lang'
+import {
+    detectLang,
+    getLangConfig,
+    pickTranslateAutoTargetLang,
+    sourceLanguages,
+    targetLanguages,
+    LangCode,
+} from '../lang'
 import { translate, TranslateMode } from '../translate'
 import { Select, Value, Option } from 'baseui-sd/select'
 import { RxEraser, RxEnter, RxReload, RxStop } from 'react-icons/rx'
@@ -962,10 +969,10 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                             isTranslate &&
                             (!stopAutomaticallyChangeTargetLang.current || newSourceLang === targetLang_)
                         ) {
-                            return (
-                                (newSourceLang === 'zh-Hans' || newSourceLang === 'zh-Hant'
-                                    ? 'en'
-                                    : (settings?.defaultTargetLanguage as LangCode | undefined)) ?? 'en'
+                            return pickTranslateAutoTargetLang(
+                                newSourceLang,
+                                settings?.defaultTargetLanguage,
+                                settings?.writingTargetLanguage
                             )
                         }
                         if (!targetLang_) {
@@ -990,7 +997,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                 })
             })
         },
-        [settings.defaultTargetLanguage]
+        [settings.defaultTargetLanguage, settings.writingTargetLanguage]
     )
 
     const { externalOriginalText } = useTranslatorStore()

--- a/src/common/lang/index.ts
+++ b/src/common/lang/index.ts
@@ -99,6 +99,31 @@ export function getLangName(langCode: string): string {
     return langName || langMap.get(langCode) || langCode
 }
 
+/**
+ * Target language when the UI follows "default target language" for translate mode.
+ * Avoids source === target (e.g. Japanese input with Japanese as default → Japanese output).
+ * Chinese variants still map to English. If source equals default target, uses
+ * {@link writingTargetLanguage} when it differs from source, otherwise English.
+ */
+export function pickTranslateAutoTargetLang(
+    sourceLang: LangCode,
+    defaultTargetLanguage: LangCode | string | undefined,
+    writingTargetLanguage: LangCode | string | undefined
+): LangCode {
+    if (sourceLang === 'zh-Hans' || sourceLang === 'zh-Hant') {
+        return 'en'
+    }
+    const defaultTarget = (defaultTargetLanguage as LangCode | undefined) ?? 'en'
+    if (sourceLang !== defaultTarget) {
+        return defaultTarget
+    }
+    const writing = (writingTargetLanguage as LangCode | undefined) ?? 'en'
+    if (writing !== sourceLang) {
+        return writing
+    }
+    return 'en'
+}
+
 export async function googleDetectLang(text: string): Promise<LangCode> {
     const langMap: Record<string, LangCode> = {
         'zh-CN': 'zh-Hans',

--- a/src/common/lang/pickTranslateAutoTargetLang.spec.ts
+++ b/src/common/lang/pickTranslateAutoTargetLang.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { pickTranslateAutoTargetLang } from './index'
+
+describe('pickTranslateAutoTargetLang', () => {
+    it('maps Chinese variants to English', () => {
+        expect(pickTranslateAutoTargetLang('zh-Hans', 'ja', 'ja')).toBe('en')
+        expect(pickTranslateAutoTargetLang('zh-Hant', 'ja', 'ja')).toBe('en')
+    })
+
+    it('uses default target when source differs', () => {
+        expect(pickTranslateAutoTargetLang('en', 'ja', 'en')).toBe('ja')
+    })
+
+    it('uses writing target when source equals default target', () => {
+        expect(pickTranslateAutoTargetLang('ja', 'ja', 'en')).toBe('en')
+    })
+
+    it('uses English when writing target also matches source', () => {
+        expect(pickTranslateAutoTargetLang('ja', 'ja', 'ja')).toBe('en')
+    })
+})


### PR DESCRIPTION
Thanks for maintaining NextAI Translator.

## Summary

When **detected source language** equals **default target language**, the auto-selected translate target could become the same as the source (e.g. Japanese → Japanese). This PR picks a **fallback target** instead.

## Context

As a Japanese user I often translate **between Japanese and English**. Setting the default target to **Japanese** is natural for EN→JP, but **JP→JP** when pasting Japanese is usually unintended.

## Changes

- Add `pickTranslateAutoTargetLang` in `src/common/lang/index.ts`: if source equals default target, use `writingTargetLanguage` when it differs from source; otherwise `en`. Existing rule unchanged: **zh-Hans / zh-Hant → en**.
- Use it in `Translator.tsx` (translate auto-target) and `InlineLookupContainer.tsx`.
- Add `pickTranslateAutoTargetLang.spec.ts` (Vitest).

## Test plan

- [ ] `pnpm test`
- [ ] `pnpm lint`