### PR TITLE
feat(writing): replace Backspace-based animation with floating HUD

### DIFF
--- a/src-tauri/src/ax_context.rs
+++ b/src-tauri/src/ax_context.rs
@@ -133,12 +133,7 @@ mod macos_impl {
             }
             let app = AXUIElement::wrap_under_create_rule(app_ref);
             let mut out: AXUIElementRef = std::ptr::null_mut();
-            let err = AXUIElementCopyElementAtPosition(
-                app.as_concrete_TypeRef(),
-                x,
-                y,
-                &mut out,
-            );
+            let err = AXUIElementCopyElementAtPosition(app.as_concrete_TypeRef(), x, y, &mut out);
             if err != accessibility_sys_ng::kAXErrorSuccess || out.is_null() {
                 return None;
             }
@@ -180,8 +175,7 @@ mod macos_impl {
                 if ptr.is_null() {
                     continue;
                 }
-                let child =
-                    unsafe { AXUIElement::wrap_under_get_rule(ptr as AXUIElementRef) };
+                let child = unsafe { AXUIElement::wrap_under_get_rule(ptr as AXUIElementRef) };
                 if !walk(&child, depth + 1, out, total) {
                     return false;
                 }

--- a/src-tauri/src/ax_context.rs
+++ b/src-tauri/src/ax_context.rs
@@ -1,0 +1,304 @@
+// Read text context from the focused / hovered Accessibility element of the
+// currently active application. Used by the Quick Translator window to guess
+// which word or sentence the user is most likely interested in.
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AxContext {
+    pub focused_text: String,
+    pub focused_role: String,
+    pub selected_text: String,
+    pub hovered_text: String,
+    pub hovered_role: String,
+    pub app_name: String,
+    pub app_bundle_id: String,
+    pub mouse_x: i32,
+    pub mouse_y: i32,
+    pub paragraphs: Vec<String>,
+    pub truncated: bool,
+}
+
+#[cfg(target_os = "macos")]
+mod macos_impl {
+    use super::AxContext;
+    use accessibility_ng::{AXAttribute, AXUIElement};
+    use accessibility_sys_ng::{
+        kAXChildrenAttribute, kAXDescriptionAttribute, kAXFocusedApplicationAttribute,
+        kAXFocusedUIElementAttribute, kAXFocusedWindowAttribute, kAXRoleAttribute,
+        kAXSelectedTextAttribute, kAXTitleAttribute, kAXValueAttribute,
+        AXUIElementCopyElementAtPosition, AXUIElementCreateApplication, AXUIElementRef,
+    };
+    use cocoa::base::{id, nil};
+    use core_foundation::array::CFArray;
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::string::CFString;
+    use objc::{class, msg_send, sel, sel_impl};
+    use std::ffi::c_void;
+
+    const MAX_TEXT_PER_NODE: usize = 1200;
+    const MAX_FOCUSED_TEXT: usize = 4000;
+    const MAX_WIDE_NODES: usize = 300;
+    const MAX_WIDE_DEPTH: usize = 8;
+    const MAX_WIDE_TOTAL: usize = 8000;
+
+    fn attr_string(elem: &AXUIElement, key: &'static str) -> Option<String> {
+        let value: CFType = elem
+            .attribute(&AXAttribute::new(&CFString::from_static_string(key)))
+            .ok()?;
+        if let Some(s) = value.downcast::<CFString>() {
+            return Some(s.to_string());
+        }
+        None
+    }
+
+    fn role(elem: &AXUIElement) -> String {
+        attr_string(elem, kAXRoleAttribute).unwrap_or_default()
+    }
+
+    fn best_text(elem: &AXUIElement) -> String {
+        for key in [
+            kAXValueAttribute,
+            kAXTitleAttribute,
+            kAXDescriptionAttribute,
+        ] {
+            if let Some(text) = attr_string(elem, key) {
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    return truncate(trimmed, MAX_TEXT_PER_NODE);
+                }
+            }
+        }
+        String::new()
+    }
+
+    fn truncate(s: &str, max: usize) -> String {
+        if s.chars().count() <= max {
+            return s.to_string();
+        }
+        let mut out = String::with_capacity(max);
+        for (i, c) in s.chars().enumerate() {
+            if i >= max {
+                break;
+            }
+            out.push(c);
+        }
+        out
+    }
+
+    fn focused_pid() -> Option<i32> {
+        let system = AXUIElement::system_wide();
+        let app: AXUIElement = system
+            .attribute(&AXAttribute::new(&CFString::from_static_string(
+                kAXFocusedApplicationAttribute,
+            )))
+            .ok()
+            .and_then(|v: CFType| v.downcast_into::<AXUIElement>())?;
+        app.pid().ok()
+    }
+
+    fn frontmost_app_info() -> (String, String) {
+        unsafe {
+            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+            let running_app: id = msg_send![workspace, frontmostApplication];
+            if running_app == nil {
+                return (String::new(), String::new());
+            }
+            let bundle_id_str: id = msg_send![running_app, bundleIdentifier];
+            let bundle_id = nsstring_to_string(bundle_id_str);
+            let name_str: id = msg_send![running_app, localizedName];
+            let name = nsstring_to_string(name_str);
+            (name, bundle_id)
+        }
+    }
+
+    unsafe fn nsstring_to_string(s: id) -> String {
+        if s == nil {
+            return String::new();
+        }
+        let bytes: *const std::os::raw::c_char = msg_send![s, UTF8String];
+        if bytes.is_null() {
+            return String::new();
+        }
+        std::ffi::CStr::from_ptr(bytes)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn element_at_position(x: f32, y: f32) -> Option<AXUIElement> {
+        let pid = focused_pid()?;
+        unsafe {
+            let app_ref = AXUIElementCreateApplication(pid);
+            if app_ref.is_null() {
+                return None;
+            }
+            let app = AXUIElement::wrap_under_create_rule(app_ref);
+            let mut out: AXUIElementRef = std::ptr::null_mut();
+            let err = AXUIElementCopyElementAtPosition(
+                app.as_concrete_TypeRef(),
+                x,
+                y,
+                &mut out,
+            );
+            if err != accessibility_sys_ng::kAXErrorSuccess || out.is_null() {
+                return None;
+            }
+            Some(AXUIElement::wrap_under_create_rule(out))
+        }
+    }
+
+    fn children(elem: &AXUIElement) -> Option<CFArray<*const c_void>> {
+        let value: CFType = elem
+            .attribute(&AXAttribute::new(&CFString::from_static_string(
+                kAXChildrenAttribute,
+            )))
+            .ok()?;
+        value.downcast_into::<CFArray<*const c_void>>()
+    }
+
+    fn walk(elem: &AXUIElement, depth: usize, out: &mut Vec<String>, total: &mut usize) -> bool {
+        if depth > MAX_WIDE_DEPTH || out.len() >= MAX_WIDE_NODES || *total >= MAX_WIDE_TOTAL {
+            return false;
+        }
+        let role = role(elem);
+        let interesting = matches!(
+            role.as_str(),
+            "AXStaticText" | "AXTextArea" | "AXTextField" | "AXHeading" | "AXLink"
+        );
+        if interesting {
+            let text = best_text(elem);
+            if !text.is_empty() {
+                *total += text.chars().count();
+                out.push(text);
+                if out.len() >= MAX_WIDE_NODES || *total >= MAX_WIDE_TOTAL {
+                    return false;
+                }
+            }
+        }
+        if let Some(kids) = children(elem) {
+            for kid in kids.iter() {
+                let ptr: *const c_void = *kid;
+                if ptr.is_null() {
+                    continue;
+                }
+                let child =
+                    unsafe { AXUIElement::wrap_under_get_rule(ptr as AXUIElementRef) };
+                if !walk(&child, depth + 1, out, total) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    pub fn read_narrow(mouse_x: i32, mouse_y: i32) -> AxContext {
+        let (app_name, app_bundle_id) = frontmost_app_info();
+        let system = AXUIElement::system_wide();
+        let focused: Option<AXUIElement> = system
+            .attribute(&AXAttribute::new(&CFString::from_static_string(
+                kAXFocusedUIElementAttribute,
+            )))
+            .ok()
+            .and_then(|v: CFType| v.downcast_into::<AXUIElement>());
+
+        let (focused_text, focused_role, selected_text) = match &focused {
+            Some(elem) => {
+                let r = role(elem);
+                let val = attr_string(elem, kAXValueAttribute).unwrap_or_default();
+                let text = if val.trim().is_empty() {
+                    best_text(elem)
+                } else {
+                    truncate(&val, MAX_FOCUSED_TEXT)
+                };
+                let sel = attr_string(elem, kAXSelectedTextAttribute).unwrap_or_default();
+                (text, r, sel)
+            }
+            None => (String::new(), String::new(), String::new()),
+        };
+
+        let hovered = element_at_position(mouse_x as f32, mouse_y as f32);
+        let (hovered_text, hovered_role) = match hovered {
+            Some(elem) => (best_text(&elem), role(&elem)),
+            None => (String::new(), String::new()),
+        };
+
+        AxContext {
+            focused_text,
+            focused_role,
+            selected_text,
+            hovered_text,
+            hovered_role,
+            app_name,
+            app_bundle_id,
+            mouse_x,
+            mouse_y,
+            paragraphs: Vec::new(),
+            truncated: false,
+        }
+    }
+
+    pub fn read_wide(mouse_x: i32, mouse_y: i32) -> AxContext {
+        let mut ctx = read_narrow(mouse_x, mouse_y);
+        let system = AXUIElement::system_wide();
+        let focused_window: Option<AXUIElement> = system
+            .attribute(&AXAttribute::new(&CFString::from_static_string(
+                kAXFocusedWindowAttribute,
+            )))
+            .ok()
+            .and_then(|v: CFType| v.downcast_into::<AXUIElement>());
+
+        if let Some(window) = focused_window {
+            let mut paragraphs = Vec::new();
+            let mut total = 0usize;
+            let fully = walk(&window, 0, &mut paragraphs, &mut total);
+            ctx.truncated = !fully;
+            ctx.paragraphs = paragraphs;
+        }
+        ctx
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn read_narrow_impl(mouse_x: i32, mouse_y: i32) -> AxContext {
+    macos_impl::read_narrow(mouse_x, mouse_y)
+}
+
+#[cfg(target_os = "macos")]
+fn read_wide_impl(mouse_x: i32, mouse_y: i32) -> AxContext {
+    macos_impl::read_wide(mouse_x, mouse_y)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_narrow_impl(mouse_x: i32, mouse_y: i32) -> AxContext {
+    AxContext {
+        mouse_x,
+        mouse_y,
+        ..AxContext::default()
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_wide_impl(mouse_x: i32, mouse_y: i32) -> AxContext {
+    AxContext {
+        mouse_x,
+        mouse_y,
+        ..AxContext::default()
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn read_ax_context_narrow() -> AxContext {
+    let (x, y) = crate::windows::get_mouse_location().unwrap_or((0, 0));
+    tokio::task::spawn_blocking(move || read_narrow_impl(x, y))
+        .await
+        .unwrap_or_default()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn read_ax_context_wide() -> AxContext {
+    let (x, y) = crate::windows::get_mouse_location().unwrap_or((0, 0));
+    tokio::task::spawn_blocking(move || read_wide_impl(x, y))
+        .await
+        .unwrap_or_default()
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -33,11 +33,11 @@ use tauri_specta::Event;
 use tray::{PinnedFromTrayEvent, PinnedFromWindowEvent};
 use windows::{get_translator_window, CheckUpdateEvent, CheckUpdateResultEvent};
 
+use crate::ax_context::{read_ax_context_narrow, read_ax_context_wide};
 use crate::config::{clear_config_cache, get_config_content, ConfigUpdatedEvent};
 use crate::fetch::fetch_stream;
 use crate::lang::detect_lang;
 use crate::ocr::{cut_image, finish_ocr, screenshot, start_ocr};
-use crate::ax_context::{read_ax_context_narrow, read_ax_context_wide};
 use crate::windows::{
     get_translator_window_always_on_top, get_writing_indicator_pending_lang,
     hide_inline_lookup_window, hide_quick_translator_window, hide_translator_window,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
     windows_subsystem = "windows"
 )]
 
+mod ax_context;
 mod config;
 mod fetch;
 mod insertion;
@@ -36,11 +37,14 @@ use crate::config::{clear_config_cache, get_config_content, ConfigUpdatedEvent};
 use crate::fetch::fetch_stream;
 use crate::lang::detect_lang;
 use crate::ocr::{cut_image, finish_ocr, screenshot, start_ocr};
+use crate::ax_context::{read_ax_context_narrow, read_ax_context_wide};
 use crate::windows::{
-    get_translator_window_always_on_top, hide_inline_lookup_window, hide_translator_window,
-    show_action_manager_window, show_history_window, show_inline_lookup_window_command,
+    get_translator_window_always_on_top, get_writing_indicator_pending_lang,
+    hide_inline_lookup_window, hide_quick_translator_window, hide_translator_window,
+    hide_writing_indicator, show_action_manager_window, show_history_window,
+    show_inline_lookup_window_command, show_quick_translator_window_command,
     show_translator_window_command, show_translator_window_with_selected_text_command,
-    show_updater_window, TRANSLATOR_WIN_NAME,
+    show_updater_window, show_writing_indicator, TRANSLATOR_WIN_NAME,
 };
 use crate::writing::{finish_writing, write_to_input, writing_command};
 
@@ -360,6 +364,9 @@ fn main() {
             writing_command,
             write_to_input,
             finish_writing,
+            show_writing_indicator,
+            hide_writing_indicator,
+            get_writing_indicator_pending_lang,
             insert_translation_into_previous_input,
             remember_active_window_command,
             detect_lang,
@@ -367,6 +374,10 @@ fn main() {
             hide_translator_window,
             hide_inline_lookup_window,
             show_inline_lookup_window_command,
+            show_quick_translator_window_command,
+            hide_quick_translator_window,
+            read_ax_context_narrow,
+            read_ax_context_wide,
             start_ocr,
             finish_ocr,
             cut_image,
@@ -438,6 +449,17 @@ fn main() {
             app_handle.plugin(tauri_plugin_updater::Builder::new().build())?;
             // create thumb window
             let _ = windows::get_thumb_window(0, 0);
+            // Pre-create the Quick Translator panel on the main thread.
+            // Window creation + raw cocoa msg_send calls (setLevel:, etc.) must
+            // run on the AppKit main thread; if we let it happen lazily inside
+            // an async Tauri command (which runs on a tokio worker thread),
+            // macOS aborts the process with
+            // "Must only be used from the main thread" / EXC_BREAKPOINT.
+            let _ = windows::get_quick_translator_window();
+            // Same main-thread-only reasoning as the Quick Translator: pre-create
+            // the writing-indicator panel here so its NSWindow + setLevel calls
+            // happen on the AppKit main thread instead of inside a tokio worker.
+            let _ = windows::get_writing_indicator_window();
             if silently {
                 // create translator window
                 let _ = get_translator_window(false, false, false);

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -412,6 +412,155 @@ pub fn is_valid_selected_frame() -> Result<bool, Box<dyn std::error::Error>> {
     }
 }
 
+/// Reads the *currently selected* text of the focused UI element via the
+/// macOS Accessibility API (kAXSelectedTextAttribute). Returns `None` if AX
+/// isn't available, no element is focused, the selection is empty, or the
+/// attribute is unsupported by the element (common in custom widgets). This is
+/// the preferred read path because it does NOT touch the clipboard, fire
+/// keystrokes, or move the cursor.
+#[cfg(target_os = "macos")]
+pub fn get_selected_text_via_ax() -> Option<String> {
+    use accessibility_ng::{AXAttribute, AXUIElement};
+    use accessibility_sys_ng::{kAXFocusedUIElementAttribute, kAXSelectedTextAttribute};
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::string::CFString;
+
+    let system = AXUIElement::system_wide();
+    let focused = system
+        .attribute(&AXAttribute::new(&CFString::from_static_string(
+            kAXFocusedUIElementAttribute,
+        )))
+        .ok()
+        .and_then(|v: CFType| v.downcast_into::<AXUIElement>())?;
+
+    let value = focused
+        .attribute(&AXAttribute::new(&CFString::from_static_string(
+            kAXSelectedTextAttribute,
+        )))
+        .ok()?;
+    let s: CFString = value.downcast::<CFString>()?;
+    let text = s.to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn get_selected_text_via_ax() -> Option<String> {
+    None
+}
+
+/// Reads the entire value of the focused UI element via the macOS
+/// Accessibility API (kAXValueAttribute). Returns `None` if AX isn't available,
+/// no element is focused, the value is empty, or the element doesn't expose
+/// a string value (e.g. password fields). Like `get_selected_text_via_ax`,
+/// this does NOT touch clipboard or fire keystrokes — the previous select-all
+/// + Cmd+C dance was visually disruptive on every trigger.
+#[cfg(target_os = "macos")]
+pub fn get_focused_text_via_ax() -> Option<String> {
+    use accessibility_ng::{AXAttribute, AXUIElement};
+    use accessibility_sys_ng::{kAXFocusedUIElementAttribute, kAXValueAttribute};
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::string::CFString;
+
+    let system = AXUIElement::system_wide();
+    let focused = system
+        .attribute(&AXAttribute::new(&CFString::from_static_string(
+            kAXFocusedUIElementAttribute,
+        )))
+        .ok()
+        .and_then(|v: CFType| v.downcast_into::<AXUIElement>())?;
+
+    let value = focused
+        .attribute(&AXAttribute::new(&CFString::from_static_string(
+            kAXValueAttribute,
+        )))
+        .ok()?;
+    let s: CFString = value.downcast::<CFString>()?;
+    let text = s.to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn get_focused_text_via_ax() -> Option<String> {
+    None
+}
+
+/// Anchor rect for the floating writing-indicator panel, in macOS *logical* screen
+/// points (top-left origin), i.e. the same coordinate space that AX position/size
+/// attributes use. Returns `None` if neither the current selection bounds nor the
+/// focused element frame are available; the caller should fall back to the mouse
+/// position in that case.
+#[cfg(target_os = "macos")]
+pub fn get_writing_anchor_rect() -> Option<(f64, f64, f64, f64)> {
+    if let Ok(rect) = get_selected_text_frame_by_ax() {
+        if rect.size.width > 0.0 && rect.size.height > 0.0 {
+            return Some((rect.origin.x, rect.origin.y, rect.size.width, rect.size.height));
+        }
+    }
+    if let Ok(rect) = get_focused_element_frame_by_ax() {
+        if rect.size.width > 0.0 && rect.size.height > 0.0 {
+            return Some((rect.origin.x, rect.origin.y, rect.size.width, rect.size.height));
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn get_writing_anchor_rect() -> Option<(f64, f64, f64, f64)> {
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn get_focused_element_frame_by_ax() -> Result<CGRect, Box<dyn std::error::Error>> {
+    use accessibility_ng::{AXAttribute, AXUIElement, AXValue};
+    use accessibility_sys_ng::{
+        kAXFocusedUIElementAttribute, kAXPositionAttribute, kAXSizeAttribute,
+    };
+    use core_foundation::string::CFString;
+    use core_graphics::geometry::{CGPoint, CGSize};
+
+    let system_element = AXUIElement::system_wide();
+    let Some(focused_element) = system_element
+        .attribute(&AXAttribute::new(&CFString::from_static_string(
+            kAXFocusedUIElementAttribute,
+        )))
+        .map(|element| element.downcast_into::<AXUIElement>())
+        .ok()
+        .flatten()
+    else {
+        return Ok(CGRect::default());
+    };
+
+    let position = focused_element
+        .attribute(&AXAttribute::new(&CFString::from_static_string(
+            kAXPositionAttribute,
+        )))
+        .map(|v| v.downcast_into::<AXValue>())
+        .ok()
+        .flatten()
+        .and_then(|v| v.get_value::<CGPoint>().ok())
+        .unwrap_or(CGPoint::new(0.0, 0.0));
+
+    let size = focused_element
+        .attribute(&AXAttribute::new(&CFString::from_static_string(
+            kAXSizeAttribute,
+        )))
+        .map(|v| v.downcast_into::<AXValue>())
+        .ok()
+        .flatten()
+        .and_then(|v| v.get_value::<CGSize>().ok())
+        .unwrap_or(CGSize::new(0.0, 0.0));
+
+    Ok(CGRect::new(&position, &size))
+}
+
 pub fn send_text(text: String) {
     match APP_HANDLE.get() {
         Some(handle) => handle.emit("change-text", text).unwrap_or_default(),

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -501,12 +501,22 @@ pub fn get_focused_text_via_ax() -> Option<String> {
 pub fn get_writing_anchor_rect() -> Option<(f64, f64, f64, f64)> {
     if let Ok(rect) = get_selected_text_frame_by_ax() {
         if rect.size.width > 0.0 && rect.size.height > 0.0 {
-            return Some((rect.origin.x, rect.origin.y, rect.size.width, rect.size.height));
+            return Some((
+                rect.origin.x,
+                rect.origin.y,
+                rect.size.width,
+                rect.size.height,
+            ));
         }
     }
     if let Ok(rect) = get_focused_element_frame_by_ax() {
         if rect.size.width > 0.0 && rect.size.height > 0.0 {
-            return Some((rect.origin.x, rect.origin.y, rect.size.width, rect.size.height));
+            return Some((
+                rect.origin.x,
+                rect.origin.y,
+                rect.size.width,
+                rect.size.height,
+            ));
         }
     }
     None

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -26,6 +26,8 @@ pub const UPDATER_WIN_NAME: &str = "updater";
 pub const THUMB_WIN_NAME: &str = "thumb";
 pub const HISTORY_WIN_NAME: &str = "history";
 pub const INLINE_LOOKUP_WIN_NAME: &str = "inline_lookup";
+pub const QUICK_TRANSLATOR_WIN_NAME: &str = "quick_translator";
+pub const WRITING_INDICATOR_WIN_NAME: &str = "writing_indicator";
 #[cfg(target_os = "windows")]
 pub const SCREENSHOT_WIN_NAME: &str = "screenshot";
 
@@ -893,4 +895,375 @@ pub fn get_screenshot_window() -> tauri::WebviewWindow {
     window.set_always_on_top(true).unwrap();
 
     window
+}
+
+#[cfg(target_os = "macos")]
+fn apply_quick_translator_panel_traits(window: &tauri::WebviewWindow) {
+    // We intentionally do NOT change the NSWindow class to NSPanel here.
+    // Tao installs its own NSWindow subclass with method overrides; replacing
+    // its class with NSPanel at runtime corrupts the responder chain and
+    // crashes the process the next time AppKit dispatches certain selectors.
+    //
+    // The "doesn't steal focus" behaviour we need is already covered by:
+    //   * the WebviewWindowBuilder is built with .focused(false)
+    //   * we never call window.set_focus() for this window
+    //   * the app activation policy is Accessory on macOS
+    // What we still tweak natively here is the window level (so the panel
+    // floats above the previously active app's windows) and behaviour on
+    // app deactivation (don't hide when our app loses focus).
+    use cocoa::base::{id, NO};
+    use objc::{msg_send, sel, sel_impl};
+
+    const NS_FLOATING_WINDOW_LEVEL: i64 = 3;
+
+    let Some(ns_win) = window.ns_window().ok().map(|p| p as id) else {
+        return;
+    };
+
+    unsafe {
+        let _: () = msg_send![ns_win, setLevel: NS_FLOATING_WINDOW_LEVEL];
+        let _: () = msg_send![ns_win, setHidesOnDeactivate: NO];
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apply_quick_translator_panel_traits(_window: &tauri::WebviewWindow) {}
+
+pub fn get_quick_translator_window() -> tauri::WebviewWindow {
+    let handle = APP_HANDLE.get().unwrap();
+    if let Some(window) = handle.get_webview_window(QUICK_TRANSLATOR_WIN_NAME) {
+        let _ = window.unminimize();
+        return window;
+    }
+
+    let builder = tauri::WebviewWindowBuilder::new(
+        handle,
+        QUICK_TRANSLATOR_WIN_NAME,
+        tauri::WebviewUrl::App("src/tauri/index.html".into()),
+    )
+    .title("")
+    .fullscreen(false)
+    .inner_size(560.0, 320.0)
+    .min_inner_size(420.0, 220.0)
+    .max_inner_size(820.0, 620.0)
+    .visible(false)
+    .resizable(true)
+    .skip_taskbar(true)
+    .minimizable(false)
+    .maximizable(false)
+    .closable(false)
+    .focused(false)
+    .decorations(false)
+    .transparent(true)
+    .shadow(true);
+
+    let window = builder.build().unwrap();
+    post_process_window(&window);
+    apply_quick_translator_panel_traits(&window);
+
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::utils::{WindowEffect, WindowEffectState};
+        use tauri::utils::config::WindowEffectsConfig;
+        let _ = window.set_effects(WindowEffectsConfig {
+            effects: vec![WindowEffect::HudWindow],
+            state: Some(WindowEffectState::Active),
+            radius: Some(14.0),
+            color: None,
+        });
+    }
+    window
+}
+
+fn position_quick_translator_window(window: &tauri::WebviewWindow) {
+    // Anchor the Quick Translator panel to the bottom-horizontal-center of the
+    // monitor that currently holds the mouse cursor, with a comfortable gap
+    // from the bottom edge (Dock-aware fallback uses a fixed margin).
+    let current_monitor = get_current_monitor();
+    let window_outer_size = match window.outer_size() {
+        Ok(size) => size,
+        Err(_) => return,
+    };
+
+    let monitor_physical_size = current_monitor.size();
+    let monitor_physical_position = current_monitor.position();
+    let scale_factor = window.scale_factor().unwrap_or(1.0);
+    let bottom_margin_logical = 96.0_f64;
+    let bottom_margin_physical = (bottom_margin_logical * scale_factor).round() as i32;
+
+    let x = monitor_physical_position.x
+        + ((monitor_physical_size.width as i32) - (window_outer_size.width as i32)) / 2;
+    let y = monitor_physical_position.y
+        + (monitor_physical_size.height as i32)
+        - (window_outer_size.height as i32)
+        - bottom_margin_physical;
+
+    let clamped_x = x.max(monitor_physical_position.x);
+    let clamped_y = y.max(monitor_physical_position.y);
+    let _ = window.set_position(PhysicalPosition::new(clamped_x, clamped_y));
+}
+
+pub fn show_quick_translator_window() -> tauri::WebviewWindow {
+    let window = get_quick_translator_window();
+    position_quick_translator_window(&window);
+    let _ = window.show();
+    let _ = window.set_always_on_top(true);
+    if let Err(e) = APP_HANDLE
+        .get()
+        .map(|h| h.emit("quick-translator-shown", ()))
+        .transpose()
+    {
+        eprintln!("failed to emit quick-translator-shown: {}", e);
+    }
+    window
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn show_quick_translator_window_command() {
+    remember_active_window();
+    show_quick_translator_window();
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn hide_quick_translator_window() {
+    if let Some(handle) = APP_HANDLE.get() {
+        if let Some(window) = handle.get_webview_window(QUICK_TRANSLATOR_WIN_NAME) {
+            let _ = window.set_always_on_top(false);
+            let _ = window.hide();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writing indicator panel
+//
+// A small floating, focus-less, click-through HUD anchored just below the
+// currently focused input box (or the selection bounds, if a selection drove
+// the writing command). Shows the "translating to <lang>" shimmer animation
+// while the Writing flow streams text into the input — replacing the old
+// behaviour where a placeholder like `<Translating ✍️>` was typed INTO the
+// input and later backspaced away (which was the root cause of over-deletion
+// when emoji grapheme widths, IME state or autocomplete made the backspace
+// count wrong).
+// ---------------------------------------------------------------------------
+
+const WRITING_INDICATOR_WIDTH: f64 = 220.0;
+const WRITING_INDICATOR_HEIGHT: f64 = 44.0;
+const WRITING_INDICATOR_ANCHOR_GAP: f64 = 8.0;
+
+#[cfg(target_os = "macos")]
+fn apply_writing_indicator_panel_traits(window: &tauri::WebviewWindow) {
+    // Same rationale as `apply_quick_translator_panel_traits`: don't reclass
+    // NSWindow to NSPanel (tao's subclass breaks). Just bump the level so the
+    // HUD floats above the previously active app, keep it visible when our app
+    // is in the background, and make it click-through so it never accidentally
+    // intercepts the user's clicks.
+    use cocoa::base::{id, NO, YES};
+    use objc::{class, msg_send, sel, sel_impl};
+
+    const NS_FLOATING_WINDOW_LEVEL: i64 = 3;
+
+    let Some(ns_win) = window.ns_window().ok().map(|p| p as id) else {
+        return;
+    };
+
+    unsafe {
+        let _: () = msg_send![ns_win, setLevel: NS_FLOATING_WINDOW_LEVEL];
+        let _: () = msg_send![ns_win, setHidesOnDeactivate: NO];
+        let _: () = msg_send![ns_win, setIgnoresMouseEvents: YES];
+        // Tauri's `.transparent(true)` alone leaves a faint background in the
+        // corners outside the React-rendered rounded card on some macOS
+        // versions. Force the NSWindow itself to draw absolutely nothing so
+        // only our rounded card is visible.
+        let clear_color: id = msg_send![class!(NSColor), clearColor];
+        let _: () = msg_send![ns_win, setBackgroundColor: clear_color];
+        let _: () = msg_send![ns_win, setOpaque: NO];
+        let _: () = msg_send![ns_win, setHasShadow: NO];
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apply_writing_indicator_panel_traits(_window: &tauri::WebviewWindow) {}
+
+pub fn get_writing_indicator_window() -> tauri::WebviewWindow {
+    let handle = APP_HANDLE.get().unwrap();
+    if let Some(window) = handle.get_webview_window(WRITING_INDICATOR_WIN_NAME) {
+        return window;
+    }
+
+    let builder = tauri::WebviewWindowBuilder::new(
+        handle,
+        WRITING_INDICATOR_WIN_NAME,
+        tauri::WebviewUrl::App("src/tauri/index.html".into()),
+    )
+    .title("")
+    .fullscreen(false)
+    .inner_size(WRITING_INDICATOR_WIDTH, WRITING_INDICATOR_HEIGHT)
+    .visible(false)
+    .resizable(false)
+    .skip_taskbar(true)
+    .minimizable(false)
+    .maximizable(false)
+    .closable(false)
+    .focused(false)
+    .decorations(false)
+    .transparent(true)
+    .shadow(false);
+
+    let window = builder.build().unwrap();
+    post_process_window(&window);
+    apply_writing_indicator_panel_traits(&window);
+
+    // Native macOS HUD vibrancy material. With the NSWindow background set to
+    // clearColor (above) the effect material is what the user actually sees
+    // outside the React content — giving a true frosted-glass appearance that
+    // looks at home on macOS instead of a flat CSS rgba background.
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::utils::config::WindowEffectsConfig;
+        use tauri::utils::{WindowEffect, WindowEffectState};
+        let _ = window.set_effects(WindowEffectsConfig {
+            effects: vec![WindowEffect::HudWindow],
+            state: Some(WindowEffectState::Active),
+            radius: Some(14.0),
+            color: None,
+        });
+    }
+
+    window
+}
+
+/// Position the indicator window centered horizontally under the anchor rect
+/// and `WRITING_INDICATOR_ANCHOR_GAP` pixels below it. Anchor coords are in
+/// macOS logical screen points (top-left origin), matching AX coordinates.
+fn position_writing_indicator_window_at_anchor(
+    window: &tauri::WebviewWindow,
+    anchor_x: f64,
+    anchor_y: f64,
+    anchor_w: f64,
+    anchor_h: f64,
+) {
+    let scale = window.scale_factor().unwrap_or(1.0);
+    let outer = match window.outer_size() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    // Convert the desired logical top-left into physical pixels.
+    let outer_logical_w = (outer.width as f64) / scale;
+    let center_logical_x = anchor_x + anchor_w / 2.0;
+    let top_logical_x = center_logical_x - outer_logical_w / 2.0;
+    let top_logical_y = anchor_y + anchor_h + WRITING_INDICATOR_ANCHOR_GAP;
+
+    let physical = LogicalPosition::new(top_logical_x, top_logical_y).to_physical::<i32>(scale);
+
+    // Clamp to the monitor that holds the anchor's center (best effort).
+    let monitor = get_current_monitor();
+    let m_pos = monitor.position();
+    let m_size = monitor.size();
+    let max_x = m_pos.x + (m_size.width as i32) - (outer.width as i32);
+    let max_y = m_pos.y + (m_size.height as i32) - (outer.height as i32);
+    let x = physical.x.clamp(m_pos.x, max_x.max(m_pos.x));
+    let y = physical.y.clamp(m_pos.y, max_y.max(m_pos.y));
+
+    let _ = window.set_position(PhysicalPosition::new(x, y));
+}
+
+fn position_writing_indicator_window_near_mouse(window: &tauri::WebviewWindow) {
+    let (mouse_logical_x, mouse_logical_y) = match get_mouse_location() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    // Treat the mouse position as a 1x1 anchor so the "below + center" math
+    // collapses to "below + center on cursor".
+    position_writing_indicator_window_at_anchor(
+        window,
+        mouse_logical_x as f64,
+        mouse_logical_y as f64,
+        1.0,
+        1.0,
+    );
+}
+
+// Cached "currently-showing" target language. We mirror it in a Mutex (in
+// addition to emitting the `writing-indicator-start` event) so that the React
+// panel can recover the state by polling at mount time. Without this, the very
+// first show often loses the event: the panel's `listen('writing-indicator-
+// -start', ...)` registers asynchronously inside useEffect, and the Rust emit
+// can race past it.
+pub static WRITING_INDICATOR_PENDING_LANG: parking_lot::Mutex<Option<String>> =
+    parking_lot::Mutex::new(None);
+
+#[tauri::command]
+#[specta::specta]
+pub async fn show_writing_indicator(target_language: String) {
+    debug_println!(
+        "[indicator] show_writing_indicator(target_language={:?})",
+        target_language
+    );
+    let window = get_writing_indicator_window();
+    match crate::writing::peek_cached_anchor() {
+        Some((x, y, w, h)) => {
+            debug_println!("[indicator] anchor (logical pts): ({},{},{},{})", x, y, w, h);
+            position_writing_indicator_window_at_anchor(&window, x, y, w, h)
+        }
+        None => {
+            debug_println!("[indicator] no AX anchor — falling back to mouse position");
+            position_writing_indicator_window_near_mouse(&window);
+        }
+    }
+
+    // Mirror state for the React mount-time poll.
+    *WRITING_INDICATOR_PENDING_LANG.lock() = Some(target_language.clone());
+
+    let _ = window.show();
+    let _ = window.set_always_on_top(true);
+    if let Some(handle) = APP_HANDLE.get() {
+        // Broadcast (not emit_to). Targeted delivery to a webview that may
+        // still be hidden has been observed to drop silently on some Tauri 2
+        // builds; broadcast always reaches whoever is listening, and only the
+        // indicator listens for this event name.
+        match handle.emit(
+            "writing-indicator-start",
+            serde_json::json!({ "targetLanguage": target_language }),
+        ) {
+            Ok(_) => {
+                debug_println!("[indicator] emitted writing-indicator-start");
+            }
+            Err(e) => {
+                debug_println!("[indicator] FAILED to emit start: {:?}", e);
+            }
+        }
+    }
+}
+
+/// Returns the target language of the currently-showing indicator, if any.
+/// React calls this on mount to recover from the case where the
+/// `writing-indicator-start` event was emitted before its listener was wired.
+#[tauri::command]
+#[specta::specta]
+pub async fn get_writing_indicator_pending_lang() -> Option<String> {
+    WRITING_INDICATOR_PENDING_LANG.lock().clone()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn hide_writing_indicator() {
+    debug_println!("[indicator] hide_writing_indicator called");
+    *WRITING_INDICATOR_PENDING_LANG.lock() = None;
+    if let Some(handle) = APP_HANDLE.get() {
+        if let Some(window) = handle.get_webview_window(WRITING_INDICATOR_WIN_NAME) {
+            let _ = window.set_always_on_top(false);
+            match window.hide() {
+                Ok(_) => {
+                    debug_println!("[indicator] window hidden");
+                }
+                Err(e) => {
+                    debug_println!("[indicator] window.hide() failed: {:?}", e);
+                }
+            }
+        }
+    }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -963,8 +963,8 @@ pub fn get_quick_translator_window() -> tauri::WebviewWindow {
 
     #[cfg(target_os = "macos")]
     {
-        use tauri::utils::{WindowEffect, WindowEffectState};
         use tauri::utils::config::WindowEffectsConfig;
+        use tauri::utils::{WindowEffect, WindowEffectState};
         let _ = window.set_effects(WindowEffectsConfig {
             effects: vec![WindowEffect::HudWindow],
             state: Some(WindowEffectState::Active),
@@ -993,8 +993,7 @@ fn position_quick_translator_window(window: &tauri::WebviewWindow) {
 
     let x = monitor_physical_position.x
         + ((monitor_physical_size.width as i32) - (window_outer_size.width as i32)) / 2;
-    let y = monitor_physical_position.y
-        + (monitor_physical_size.height as i32)
+    let y = monitor_physical_position.y + (monitor_physical_size.height as i32)
         - (window_outer_size.height as i32)
         - bottom_margin_physical;
 
@@ -1206,7 +1205,13 @@ pub async fn show_writing_indicator(target_language: String) {
     let window = get_writing_indicator_window();
     match crate::writing::peek_cached_anchor() {
         Some((x, y, w, h)) => {
-            debug_println!("[indicator] anchor (logical pts): ({},{},{},{})", x, y, w, h);
+            debug_println!(
+                "[indicator] anchor (logical pts): ({},{},{},{})",
+                x,
+                y,
+                w,
+                h
+            );
             position_writing_indicator_window_at_anchor(&window, x, y, w, h)
         }
         None => {

--- a/src-tauri/src/writing.rs
+++ b/src-tauri/src/writing.rs
@@ -1,37 +1,72 @@
-use crate::utils::{backspace_click, left_arrow_click, right_arrow_click, select_all, INPUT_LOCK};
+// Writing flow: stream a translation into whatever input box the user has
+// focused in their active app.
+//
+// HISTORY / DESIGN NOTE
+// ---------------------
+// The previous implementation typed a status placeholder ("<Translating ✍️>",
+// later " ✅") *into* the input as a progress animation and then removed it
+// with simulated Backspace keystrokes. That was the root cause of the
+// "Writing eats extra characters" bug: `backspace_click` blindly sends N
+// `key code 51` events via AppleScript with no knowledge of grapheme widths
+// (e.g. `✍️` = U+270D + U+FE0F is 2 Rust chars but one grapheme, so most
+// fields treat one Backspace as deleting the whole emoji → off-by-one),
+// IME composition state, autocomplete, or whether the cursor is still where
+// we think it is.
+//
+// The fix: the "translating…" / "done" indicator now lives in a separate
+// floating panel (see `windows::get_writing_indicator_window`) anchored just
+// below the input. This module no longer types anything decorative into the
+// user's input and no longer simulates Backspace or arrow keys. The only
+// keystrokes it produces are the literal translated text itself, optionally
+// preceded by ⌘A (select-all) to replace the existing content.
+//
+// As a consequence, the old "incremental re-edit + invisible fingerprint"
+// optimisation (which surgically patched diffs in already-translated text
+// using arrow keys + Backspace) has been removed — re-triggering writing on
+// already-translated text now performs a full select-all + retype, which is
+// the only way to guarantee zero over-deletion.
+
+use crate::utils::{
+    get_focused_text_via_ax, get_selected_text_by_clipboard, get_selected_text_via_ax,
+    get_writing_anchor_rect, select_all, INPUT_LOCK,
+};
 use crate::APP_HANDLE;
 use debug_print::debug_println;
 use enigo::*;
 use parking_lot::Mutex;
-use similar::utils::diff_chars;
-use similar::{Algorithm, ChangeTag};
 use std::{thread, time::Duration};
+use tauri::{Emitter, Manager};
 use tauri_plugin_aptabase::EventTracker;
 
-pub fn get_input_text(
-    enigo: &mut Enigo,
-    cancel_select: bool,
-) -> Result<String, Box<dyn std::error::Error>> {
-    select_all(enigo);
-    return crate::utils::get_selected_text_by_clipboard(enigo, cancel_select);
-}
-
 static IS_WRITING: Mutex<bool> = Mutex::new(false);
-static TRANSLATE_SELECTED_TEXT_PLACEHOLDER: &str = "<Translating ✍️>";
-static IS_TRANSLATE_SELECTED_TEXT: Mutex<bool> = Mutex::new(false);
-static PREVIOUS_TRANSLATED_TEXT: Mutex<String> = Mutex::new(String::new());
-static ALL_TRANSLATED_FINGERPRINT: &str = "‌";
-static ALL_TRANSLATED_FINGERPRINT_COUNT: Mutex<usize> = Mutex::new(1);
-static NEED_TO_ADD_FINGERPRINT: Mutex<bool> = Mutex::new(false);
+static IS_FIRST_CHUNK: Mutex<bool> = Mutex::new(true);
 
-#[derive(Clone)]
-struct IncrementalAction {
-    left_arrow_click_count: usize,
-    right_arrow_click_count: usize,
-    insertion_content: String,
+/// How the first streamed chunk should erase whatever's currently in the input.
+#[derive(Clone, Copy)]
+enum FirstChunkMode {
+    /// The user had a selection when they triggered writing; the selection is
+    /// still active, so simply typing the chunk replaces it (zero extra
+    /// keystrokes, zero Backspace).
+    ReplaceSelection,
+    /// No selection — we're rewriting the whole field. Issue ⌘A right before
+    /// the first chunk so typing replaces all existing content.
+    SelectAllThenType,
 }
 
-static INCREMENTAL_ACTIONS: Mutex<Vec<IncrementalAction>> = Mutex::new(Vec::new());
+static FIRST_CHUNK_MODE: Mutex<FirstChunkMode> = Mutex::new(FirstChunkMode::SelectAllThenType);
+
+/// Anchor rect (logical screen points, top-left origin) captured at the moment
+/// `writing_command` ran — *before* anything moved focus or changed selection.
+/// The frontend later asks `show_writing_indicator` (in `windows.rs`) to read
+/// this so the indicator panel can be placed under the right input.
+static CACHED_ANCHOR: Mutex<Option<(f64, f64, f64, f64)>> = Mutex::new(None);
+
+/// Non-destructive read of the most recent anchor rect. The anchor lives until
+/// the *next* `writing_command` overwrites it, so duplicate / re-triggered
+/// indicator shows still get a valid position.
+pub fn peek_cached_anchor() -> Option<(f64, f64, f64, f64)> {
+    *CACHED_ANCHOR.lock()
+}
 
 struct WritingGuard {
     committed: bool,
@@ -55,10 +90,17 @@ impl WritingGuard {
 impl Drop for WritingGuard {
     fn drop(&mut self) {
         if !self.committed {
-            let mut is_writing = IS_WRITING.lock();
-            *is_writing = false;
+            *IS_WRITING.lock() = false;
         }
     }
+}
+
+pub fn get_input_text(
+    enigo: &mut Enigo,
+    cancel_select: bool,
+) -> Result<String, Box<dyn std::error::Error>> {
+    select_all(enigo);
+    get_selected_text_by_clipboard(enigo, cancel_select)
 }
 
 #[tauri::command]
@@ -71,225 +113,71 @@ pub fn writing_command() {
     };
     let app_handle = APP_HANDLE.get().unwrap();
     let _ = app_handle.track_event("writing", None);
-    {
-        let mut incremental_actions = INCREMENTAL_ACTIONS.lock();
-        incremental_actions.clear();
-    }
-    let mut is_translate_selected_text = IS_TRANSLATE_SELECTED_TEXT.lock();
+
+    // Reset per-invocation state.
+    *IS_FIRST_CHUNK.lock() = true;
+
+    // Snapshot the anchor rect (selection bounds, falling back to focused
+    // element frame) BEFORE we touch the clipboard / fire ⌘C, so the indicator
+    // panel can sit exactly under the input the user just acted on.
+    *CACHED_ANCHOR.lock() = get_writing_anchor_rect();
+
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
-    let selected_text =
-        crate::utils::get_selected_text_by_clipboard(&mut enigo, false).unwrap_or_default();
-    if !selected_text.is_empty() {
-        *is_translate_selected_text = true;
-        do_write_to_input(
-            &mut enigo,
-            TRANSLATE_SELECTED_TEXT_PLACEHOLDER.to_owned(),
-            false,
+
+    // PREFERRED PATH (clean): read selection/value straight from the macOS
+    // Accessibility tree. No clipboard hijack, no ⌘A flash, no cursor jump.
+    //
+    // FALLBACK: if AX returns nothing (app doesn't expose AX, custom Electron
+    // input, focused element doesn't support the attribute, accessibility
+    // permission denied, non-macOS, etc.), drop down to the old select-all +
+    // copy dance. That path still works everywhere; it's just dirty.
+    if let Some(selected_text) = get_selected_text_via_ax() {
+        debug_println!(
+            "[writing] read selection via AX ({} chars)",
+            selected_text.chars().count()
         );
+        *FIRST_CHUNK_MODE.lock() = FirstChunkMode::ReplaceSelection;
         writing_guard.commit();
         crate::utils::writing_text(selected_text);
         return;
     }
-    *is_translate_selected_text = false;
-    let mut previous_translated_text = PREVIOUS_TRANSLATED_TEXT.lock();
-    let mut content = get_input_text(&mut enigo, true).unwrap_or_default();
-    if content.is_empty() {
-        *previous_translated_text = content;
-        return;
-    }
-    if content.ends_with("\r\n") {
-        content = content[..content.len() - 2].to_owned();
-    }
-    let mut content = content.replace("\r\n", "\n");
-    if content.trim().is_empty() {
-        *previous_translated_text = content;
-        return;
-    }
-    debug_println!("[writing] content: {:?}", content.chars());
-    debug_println!(
-        "[writing] previous_translated_text: {:?}",
-        previous_translated_text.chars()
-    );
-    let changeset = diff_chars(Algorithm::Myers, &*previous_translated_text, &content);
-    debug_println!("[writing] changeset: {:?}", changeset);
-    let modifications_count = changeset
-        .iter()
-        .filter(|(change_tag, _)| match change_tag {
-            ChangeTag::Insert => true,
-            ChangeTag::Delete => true,
-            _ => false,
-        })
-        .count();
-    let translated_fingerprint_count = ALL_TRANSLATED_FINGERPRINT_COUNT.lock();
-    let mut is_all_translated_before = content
-        .starts_with(&ALL_TRANSLATED_FINGERPRINT.repeat(*translated_fingerprint_count))
-        && !content
-            .starts_with(&ALL_TRANSLATED_FINGERPRINT.repeat(*translated_fingerprint_count + 1));
-    let mut need_to_add_fingerprint = NEED_TO_ADD_FINGERPRINT.lock();
-    *need_to_add_fingerprint = false;
-
-    if !is_all_translated_before {
-        match changeset.iter().next().clone() {
-            Some(change) => match change {
-                (ChangeTag::Delete, text) => {
-                    if *text == ALL_TRANSLATED_FINGERPRINT.repeat(*translated_fingerprint_count) {
-                        *need_to_add_fingerprint = true;
-                        is_all_translated_before = true;
-                    }
-                }
-                _ => {}
-            },
-            None => {}
-        }
-        if !is_all_translated_before && changeset.len() >= 2 {
-            let first_change = changeset.iter().next().unwrap();
-            let second_change = changeset.iter().nth(1).unwrap();
-            match (first_change, second_change) {
-                ((ChangeTag::Insert, _), (ChangeTag::Equal, text)) => {
-                    if text.starts_with(
-                        &ALL_TRANSLATED_FINGERPRINT.repeat(*translated_fingerprint_count),
-                    ) && !text.starts_with(
-                        &ALL_TRANSLATED_FINGERPRINT.repeat(*translated_fingerprint_count + 1),
-                    ) {
-                        *need_to_add_fingerprint = true;
-                        is_all_translated_before = true;
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    debug_println!("is_all_translated_before: {:?}", is_all_translated_before);
-    if !previous_translated_text.is_empty()
-        && modifications_count > 0
-        && modifications_count < 10
-        && is_all_translated_before
-    {
-        let mut incremental_actions = Vec::new();
-        let mut is_first_insertion = true;
-        let mut prev_insertion_index = 0;
-        for i in 0..changeset.len() {
-            let change = &changeset[i];
-            let insertion_content = match change {
-                (ChangeTag::Insert, content) => content,
-                _ => continue,
-            };
-            if insertion_content.trim().is_empty() {
-                continue;
-            }
-            let mut prefix_newline_count = 0;
-            for c in insertion_content.chars() {
-                if c == '\n' {
-                    prefix_newline_count += 1;
-                } else {
-                    break;
-                }
-            }
-            let mut suffix_newline_count = 0;
-            for c in insertion_content.chars().rev() {
-                if c == '\n' {
-                    suffix_newline_count += 1;
-                } else {
-                    break;
-                }
-            }
-            let mut left_arrow_click_count = 0;
-            let mut right_arrow_click_count = 0;
-            if is_first_insertion {
-                is_first_insertion = false;
-                left_arrow_click_count =
-                    changeset[i + 1..]
-                        .iter()
-                        .fold(0, |acc, change| match change {
-                            (ChangeTag::Insert, text) => acc + text.chars().count(),
-                            (ChangeTag::Equal, text) => acc + text.chars().count(),
-                            _ => acc,
-                        })
-                        + suffix_newline_count;
-            } else {
-                right_arrow_click_count = changeset[prev_insertion_index + 1..i].iter().fold(
-                    0,
-                    |acc, change| match change {
-                        (ChangeTag::Insert, text) => acc + text.chars().count(),
-                        (ChangeTag::Equal, text) => acc + text.chars().count(),
-                        _ => acc,
-                    },
-                ) + prefix_newline_count;
-            }
-            prev_insertion_index = i;
-            let insertion_content = insertion_content
-                [prefix_newline_count..insertion_content.len() - suffix_newline_count]
-                .to_owned();
-            let incremental_action = IncrementalAction {
-                left_arrow_click_count,
-                right_arrow_click_count,
-                insertion_content,
-            };
-            incremental_actions.push(incremental_action);
-        }
-        if incremental_actions.is_empty() {
-            *previous_translated_text = content;
+    if let Some(content) = get_focused_text_via_ax() {
+        let content = content.replace("\r\n", "\n");
+        let trimmed_empty = content.trim().is_empty();
+        if !trimmed_empty {
+            debug_println!(
+                "[writing] read full value via AX ({} chars)",
+                content.chars().count()
+            );
+            *FIRST_CHUNK_MODE.lock() = FirstChunkMode::SelectAllThenType;
+            writing_guard.commit();
+            crate::utils::writing_text(content);
             return;
         }
+    }
+
+    debug_println!("[writing] AX returned nothing — falling back to clipboard read");
+    let selected_text = get_selected_text_by_clipboard(&mut enigo, false).unwrap_or_default();
+    if !selected_text.is_empty() {
+        *FIRST_CHUNK_MODE.lock() = FirstChunkMode::ReplaceSelection;
         writing_guard.commit();
-        thread::spawn(move || {
-            let mut global_incremental_actions = INCREMENTAL_ACTIONS.lock();
-            let reversed_incremental_actions = incremental_actions
-                .iter()
-                .rev()
-                .map(|action| action.to_owned())
-                .collect::<Vec<_>>();
-            let incremental_action =
-                reversed_incremental_actions[reversed_incremental_actions.len() - 1].clone();
-            *global_incremental_actions = reversed_incremental_actions;
-            do_incremental_writing(&incremental_action);
-        });
+        crate::utils::writing_text(selected_text);
         return;
     }
-    select_all(&mut enigo);
-    thread::sleep(Duration::from_millis(30));
-    do_write_to_input(&mut enigo, "Translating... ✍️".to_string(), false);
-
-    if content.starts_with(&ALL_TRANSLATED_FINGERPRINT.repeat(*translated_fingerprint_count))
-        && !content
-            .starts_with(&ALL_TRANSLATED_FINGERPRINT.repeat(*translated_fingerprint_count + 1))
-    {
-        // use chars to get string slice
-        let mut translated_text = String::new();
-        for c in content.chars().skip(*translated_fingerprint_count) {
-            translated_text.push(c);
-        }
-        content = translated_text;
+    let mut content = get_input_text(&mut enigo, true).unwrap_or_default();
+    if content.ends_with("\r\n") {
+        content.truncate(content.len() - 2);
     }
+    let content = content.replace("\r\n", "\n");
+    if content.trim().is_empty() {
+        return;
+    }
+    debug_println!("[writing] clipboard content: {:?}", content.chars());
+
+    *FIRST_CHUNK_MODE.lock() = FirstChunkMode::SelectAllThenType;
     writing_guard.commit();
     crate::utils::writing_text(content);
 }
-
-fn do_incremental_writing(incremental_action: &IncrementalAction) {
-    let mut enigo = Enigo::new(&Settings::default()).unwrap();
-    if incremental_action.left_arrow_click_count > 0 {
-        left_arrow_click(&mut enigo, incremental_action.left_arrow_click_count);
-    } else if incremental_action.right_arrow_click_count > 0 {
-        right_arrow_click(
-            &mut enigo,
-            incremental_action.right_arrow_click_count
-                + incremental_action.insertion_content.chars().count(),
-        );
-    }
-    backspace_click(
-        &mut enigo,
-        incremental_action.insertion_content.chars().count(),
-    );
-    do_write_to_input(
-        &mut enigo,
-        TRANSLATE_SELECTED_TEXT_PLACEHOLDER.to_owned(),
-        false,
-    );
-    crate::utils::writing_text(incremental_action.insertion_content.to_owned());
-}
-
-static IS_START_WRITING: Mutex<bool> = Mutex::new(false);
 
 fn do_write_to_input(enigo: &mut Enigo, text: String, animation: bool) {
     let _guard = INPUT_LOCK.lock();
@@ -300,7 +188,7 @@ fn do_write_to_input(enigo: &mut Enigo, text: String, animation: bool) {
                 if let Ok(config) = crate::config::get_config() {
                     if let Some(writing_newline_hotkey) = config.writing_newline_hotkey {
                         let keys = writing_newline_hotkey
-                            .split("+")
+                            .split('+')
                             .map(|c| c.trim())
                             .collect::<Vec<&str>>();
                         for key in &keys {
@@ -364,100 +252,70 @@ fn do_write_to_input(enigo: &mut Enigo, text: String, animation: bool) {
 #[tauri::command]
 #[specta::specta]
 pub fn write_to_input(text: String) {
-    let is_translate_selected_text = IS_TRANSLATE_SELECTED_TEXT.lock();
-    let incremental_contents = INCREMENTAL_ACTIONS.lock();
-    let is_incremental_translate = !incremental_contents.is_empty();
-    let mut is_start_writing = IS_START_WRITING.lock();
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
-    let mut new_text = text.clone();
-    let is_first_writing = !*is_start_writing;
-    let mut need_to_add_fingerprint = false;
-    if is_first_writing {
-        if !*is_translate_selected_text && !is_incremental_translate {
-            select_all(&mut enigo);
-            thread::sleep(Duration::from_millis(50));
-            need_to_add_fingerprint = true;
-        } else {
-            backspace_click(
-                &mut enigo,
-                TRANSLATE_SELECTED_TEXT_PLACEHOLDER
-                    .to_owned()
-                    .chars()
-                    .count()
-                    - 1,
-            );
+
+    let mut is_first = IS_FIRST_CHUNK.lock();
+    if *is_first {
+        *is_first = false;
+        match *FIRST_CHUNK_MODE.lock() {
+            FirstChunkMode::SelectAllThenType => {
+                // Replace existing content by selecting all then typing the
+                // chunk over it. No Backspace involved.
+                select_all(&mut enigo);
+                thread::sleep(Duration::from_millis(50));
+            }
+            FirstChunkMode::ReplaceSelection => {
+                // The user's original selection is still active (we never
+                // cancelled it in `writing_command`); typing replaces it.
+                // Intentionally no keystroke here.
+            }
         }
     }
-    let mut global_need_to_add_fingerprint = NEED_TO_ADD_FINGERPRINT.lock();
-    if need_to_add_fingerprint || *global_need_to_add_fingerprint {
-        *global_need_to_add_fingerprint = false;
-        let mut translated_fingerprint_count = ALL_TRANSLATED_FINGERPRINT_COUNT.lock();
-        *translated_fingerprint_count += 1;
-        if *translated_fingerprint_count > 7 {
-            *translated_fingerprint_count = 1;
-        }
-        new_text = format!(
-            "{}{}",
-            ALL_TRANSLATED_FINGERPRINT.repeat(*translated_fingerprint_count),
-            text
-        );
-    }
-    *is_start_writing = true;
-    do_write_to_input(&mut enigo, new_text, true);
+    drop(is_first);
+
+    do_write_to_input(&mut enigo, text, true);
 }
 
 #[tauri::command]
 #[specta::specta]
 pub fn finish_writing() {
-    let mut is_writing = IS_WRITING.lock();
-    *is_writing = false;
-    let mut is_start_writing = IS_START_WRITING.lock();
-    let mut enigo = Enigo::new(&Settings::default()).unwrap();
-    *is_start_writing = false;
-
-    let mut incremental_actions = INCREMENTAL_ACTIONS.lock();
-
-    let is_incremental_translate_in_the_middle = {
-        if incremental_actions.is_empty() {
-            false
-        } else {
-            let incremental_action = &incremental_actions[incremental_actions.len() - 1];
-            incremental_action.left_arrow_click_count > 0
-        }
-    };
-    if is_incremental_translate_in_the_middle {
-        do_write_to_input(&mut enigo, " ".to_string(), false);
-    }
-
-    if incremental_actions.len() > 1 {
-        let mut new_incremental_actions = incremental_actions.clone();
-        new_incremental_actions.pop().unwrap();
-        let incremental_action = new_incremental_actions[new_incremental_actions.len() - 1].clone();
-        *incremental_actions = new_incremental_actions;
-        do_incremental_writing(&incremental_action);
-    } else {
-        incremental_actions.clear();
-
-        do_write_to_input(&mut enigo, " ✅".to_string(), true);
-        thread::sleep(Duration::from_millis(300));
-
-        backspace_click(&mut enigo, 2);
-        thread::sleep(Duration::from_millis(50));
-
-        let input_text = get_input_text(&mut enigo, true).unwrap_or_default();
-        let input_text = input_text.replace("\r\n", "\n");
-
-        let fingerprint_count = input_text
-            .chars()
-            .take_while(|c| *c == ALL_TRANSLATED_FINGERPRINT.chars().next().unwrap())
-            .count();
-        if fingerprint_count > 0 {
-            let mut global_all_translated_fingerprint_count =
-                ALL_TRANSLATED_FINGERPRINT_COUNT.lock();
-            *global_all_translated_fingerprint_count = fingerprint_count;
+    debug_println!("[writing] finish_writing called");
+    *IS_WRITING.lock() = false;
+    *IS_FIRST_CHUNK.lock() = true;
+    // Tell the indicator panel to flash "done", THEN hide the window from Rust
+    // ourselves. Previously we relied on React to chain setTimeout → call
+    // `hideWritingIndicator()` — but the dev-build logs showed the panel's
+    // listener was not firing reliably across all macOS/Tauri builds (the
+    // broadcast emit succeeded but the JS-side `listen('writing-indicator-
+    // -finish', ...)` callback never ran). So hiding is now Rust-authoritative
+    // and React's only job is the visual "Done" flash if it does receive the
+    // event.
+    //
+    // Why 700ms: matches React's "hold Done before fade" duration. If React
+    // received the finish event it played the check + fade in that window;
+    // if not, the user just sees the bar disappear cleanly after the same
+    // delay. No more 1.5s ghost panel.
+    if let Some(handle) = APP_HANDLE.get() {
+        match handle.emit("writing-indicator-finish", ()) {
+            Ok(_) => {
+                debug_println!("[writing] emitted writing-indicator-finish");
+            }
+            Err(e) => {
+                debug_println!("[writing] FAILED to emit finish: {:?}", e);
+            }
         }
 
-        let mut previous_translated_text = PREVIOUS_TRANSLATED_TEXT.lock();
-        *previous_translated_text = input_text;
+        let handle_clone = handle.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(700));
+            *crate::windows::WRITING_INDICATOR_PENDING_LANG.lock() = None;
+            if let Some(window) =
+                handle_clone.get_webview_window(crate::windows::WRITING_INDICATOR_WIN_NAME)
+            {
+                let _ = window.set_always_on_top(false);
+                let _ = window.hide();
+                debug_println!("[writing] indicator window hidden by Rust authoritative path");
+            }
+        });
     }
 }

--- a/src/common/components/QuickTranslator.tsx
+++ b/src/common/components/QuickTranslator.tsx
@@ -1,0 +1,654 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createUseStyles } from 'react-jss'
+import { useTranslation } from 'react-i18next'
+import { RxCross2 } from 'react-icons/rx'
+import { IThemedStyleProps } from '../types'
+import { useTheme } from '../hooks/useTheme'
+import { useSettings } from '../hooks/useSettings'
+import { getEngine } from '../engines'
+import { translate } from '../translate'
+import { detectLang, LangCode } from '../lang'
+import { actionInternalService } from '../internal-services/action'
+import { historyInternalService } from '../internal-services/history'
+import { Markdown } from './Markdown'
+import { SpinnerIcon } from './SpinnerIcon'
+
+export interface AxContext {
+    focusedText: string
+    focusedRole: string
+    selectedText: string
+    hoveredText: string
+    hoveredRole: string
+    appName: string
+    appBundleId: string
+    mouseX: number
+    mouseY: number
+    paragraphs: string[]
+    truncated: boolean
+}
+
+export type CandidateType = 'word' | 'phrase' | 'sentence'
+
+export interface Candidate {
+    text: string
+    type: CandidateType
+    reason: string
+}
+
+export interface QuickTranslatorProps {
+    fetchContext: (wide: boolean) => Promise<AxContext>
+    onClose: () => void
+    onHide: () => void
+}
+
+const hairline = (themeType: string) => (themeType === 'dark' ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.07)')
+const subtleSurface = (themeType: string) => (themeType === 'dark' ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)')
+const hoverSurface = (themeType: string) => (themeType === 'dark' ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)')
+const activeFill = (themeType: string) => (themeType === 'dark' ? 'rgba(255,255,255,0.13)' : 'rgba(0,0,0,0.08)')
+
+const useStyles = createUseStyles({
+    'container': () => ({
+        'display': 'flex',
+        'flexDirection': 'column',
+        'height': '100vh',
+        'background': 'transparent',
+        'fontSize': '13px',
+        'lineHeight': 1.5,
+        'letterSpacing': '-0.005em',
+        'WebkitFontSmoothing': 'antialiased',
+        'MozOsxFontSmoothing': 'grayscale',
+        'textRendering': 'optimizeLegibility',
+        'overflow': 'hidden',
+        'animation': '$panelIn 220ms cubic-bezier(0.16, 1, 0.3, 1)',
+        '& ::-webkit-scrollbar': {
+            width: '6px',
+            height: '6px',
+        },
+        '& ::-webkit-scrollbar-thumb': {
+            'borderRadius': '3px',
+            'background': 'rgba(128,128,128,0.18)',
+            '&:hover': { background: 'rgba(128,128,128,0.32)' },
+        },
+    }),
+    '@keyframes panelIn': {
+        '0%': { opacity: 0, transform: 'translateY(6px) scale(0.985)' },
+        '100%': { opacity: 1, transform: 'translateY(0) scale(1)' },
+    },
+    'header': (props: IThemedStyleProps) => ({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '10px',
+        padding: '11px 14px 9px',
+        flexShrink: 0,
+        userSelect: 'none',
+        color: props.theme.colors.contentSecondary,
+    }),
+    'brand': (props: IThemedStyleProps) => ({
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        minWidth: 0,
+        color: props.theme.colors.contentSecondary,
+    }),
+    'dot': () => ({
+        width: '6px',
+        height: '6px',
+        borderRadius: '50%',
+        background: 'linear-gradient(135deg, #ff8a4c 0%, #c14fcb 60%, #5d6cff 100%)',
+        boxShadow: '0 0 8px rgba(125,90,255,0.35)',
+        flexShrink: 0,
+    }),
+    'title': (props: IThemedStyleProps) => ({
+        fontSize: '10.5px',
+        fontWeight: 600,
+        letterSpacing: '0.09em',
+        textTransform: 'uppercase',
+        color: props.theme.colors.contentSecondary,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    }),
+    'titleSeparator': () => ({
+        opacity: 0.4,
+        margin: '0 2px',
+    }),
+    'titleHost': (props: IThemedStyleProps) => ({
+        textTransform: 'none',
+        letterSpacing: 0,
+        fontSize: '11px',
+        fontWeight: 500,
+        color: props.theme.colors.contentTertiary,
+    }),
+    'closeBtn': (props: IThemedStyleProps) => ({
+        'display': 'flex',
+        'alignItems': 'center',
+        'justifyContent': 'center',
+        'width': '22px',
+        'height': '22px',
+        'borderRadius': '11px',
+        'cursor': 'pointer',
+        'opacity': 0.55,
+        'color': props.theme.colors.contentSecondary,
+        'border': 'none',
+        'background': 'transparent',
+        'transition': 'opacity 0.15s ease, background 0.15s ease, transform 0.15s ease',
+        '&:hover': {
+            opacity: 1,
+            background: hoverSurface(props.themeType ?? 'light'),
+            transform: 'scale(1.05)',
+        },
+        '&:active': {
+            transform: 'scale(0.95)',
+        },
+    }),
+    'candidatesArea': () => ({
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '6px',
+        padding: '0 14px 12px',
+        flexShrink: 0,
+    }),
+    'candidatesEmpty': (props: IThemedStyleProps) => ({
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        padding: '4px 0',
+        fontSize: '12px',
+        color: props.theme.colors.contentTertiary,
+    }),
+    'chip': (props: IThemedStyleProps) => ({
+        'display': 'inline-flex',
+        'alignItems': 'baseline',
+        'gap': '6px',
+        'padding': '5px 10px 5px 8px',
+        'borderRadius': '999px',
+        'border': `1px solid ${hairline(props.themeType ?? 'light')}`,
+        'background': subtleSurface(props.themeType ?? 'light'),
+        'color': props.theme.colors.contentPrimary,
+        'cursor': 'pointer',
+        'fontSize': '12.5px',
+        'fontWeight': 500,
+        'lineHeight': 1.25,
+        'transition': 'background 0.12s ease, border-color 0.12s ease, transform 0.1s ease',
+        'maxWidth': '100%',
+        '&:hover': {
+            background: hoverSurface(props.themeType ?? 'light'),
+        },
+        '&:active': {
+            transform: 'scale(0.98)',
+        },
+    }),
+    'chipActive': (props: IThemedStyleProps) => ({
+        background: activeFill(props.themeType ?? 'light'),
+        borderColor: props.themeType === 'dark' ? 'rgba(255,255,255,0.22)' : 'rgba(0,0,0,0.14)',
+        color: props.theme.colors.contentPrimary,
+        boxShadow:
+            props.themeType === 'dark'
+                ? '0 0 0 1px rgba(255,255,255,0.04) inset'
+                : '0 0 0 1px rgba(255,255,255,0.7) inset',
+    }),
+    'chipKind': (props: IThemedStyleProps) => ({
+        fontSize: '9px',
+        textTransform: 'uppercase',
+        letterSpacing: '0.07em',
+        color: props.theme.colors.contentTertiary,
+        fontWeight: 600,
+        transform: 'translateY(-1px)',
+    }),
+    'chipText': () => ({
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        maxWidth: '320px',
+    }),
+    'divider': (props: IThemedStyleProps) => ({
+        height: '1px',
+        background: hairline(props.themeType ?? 'light'),
+        marginInline: '14px',
+        flexShrink: 0,
+    }),
+    'translationArea': (props: IThemedStyleProps) => ({
+        flex: 1,
+        overflowY: 'auto',
+        padding: '14px 16px 12px',
+        color: props.theme.colors.contentPrimary,
+        fontSize: '14px',
+        lineHeight: 1.65,
+        userSelect: 'text',
+    }),
+    'translationPlaceholder': (props: IThemedStyleProps) => ({
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        color: props.theme.colors.contentTertiary,
+        fontSize: '12.5px',
+    }),
+    'errorMsg': (props: IThemedStyleProps) => ({
+        color: props.theme.colors.contentNegative ?? '#d44',
+        fontSize: '12.5px',
+    }),
+    'footer': (props: IThemedStyleProps) => ({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '10px',
+        padding: '8px 14px 10px',
+        fontSize: '11px',
+        color: props.theme.colors.contentTertiary,
+        flexShrink: 0,
+        userSelect: 'none',
+    }),
+    'footerHint': () => ({
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        opacity: 0.85,
+    }),
+    'kbd': (props: IThemedStyleProps) => ({
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: '16px',
+        height: '16px',
+        padding: '0 4px',
+        borderRadius: '4px',
+        fontSize: '10px',
+        fontWeight: 600,
+        border: `1px solid ${hairline(props.themeType ?? 'light')}`,
+        background: subtleSurface(props.themeType ?? 'light'),
+        color: props.theme.colors.contentSecondary,
+    }),
+    'actionBtn': (props: IThemedStyleProps) => ({
+        'border': 'none',
+        'background': 'transparent',
+        'cursor': 'pointer',
+        'color': props.theme.colors.contentSecondary,
+        'fontSize': '11px',
+        'padding': '3px 8px',
+        'borderRadius': '6px',
+        'transition': 'background 0.12s ease, color 0.12s ease',
+        '&:hover': {
+            background: hoverSurface(props.themeType ?? 'light'),
+            color: props.theme.colors.contentPrimary,
+        },
+        '&:disabled': {
+            opacity: 0.35,
+            cursor: 'default',
+            background: 'transparent',
+        },
+    }),
+    'caret': () => ({
+        display: 'inline-block',
+        width: '0.45em',
+        marginLeft: '2px',
+        borderRight: '0.16em solid currentColor',
+        animation: '$caret 700ms ease-in-out infinite',
+    }),
+    '@keyframes caret': {
+        '0%, 100%': { borderColor: 'currentColor' },
+        '50%': { borderColor: 'transparent' },
+    },
+})
+
+function clipText(text: string, max = 180): string {
+    if (!text) return ''
+    const flat = text.replace(/\s+/g, ' ').trim()
+    return flat.length > max ? flat.slice(0, max) + '…' : flat
+}
+
+function summarizeContext(ctx: AxContext): string {
+    const parts: string[] = []
+    if (ctx.selectedText.trim()) parts.push(`USER_SELECTED: "${clipText(ctx.selectedText, 200)}"`)
+    if (ctx.hoveredText.trim()) parts.push(`UNDER_CURSOR: "${clipText(ctx.hoveredText, 220)}"`)
+    if (ctx.focusedText.trim()) parts.push(`FOCUSED_ELEMENT: "${clipText(ctx.focusedText, 600)}"`)
+    if (ctx.paragraphs.length) {
+        const joined = ctx.paragraphs.map((p) => clipText(p, 280)).join('\n')
+        parts.push(`WINDOW_PARAGRAPHS:\n${joined}`)
+    }
+    if (ctx.appName) parts.push(`APP: ${ctx.appName}${ctx.appBundleId ? ` (${ctx.appBundleId})` : ''}`)
+    return parts.join('\n\n')
+}
+
+function summarizeHistory(items: Array<{ text: string; createdAt: number }>): string {
+    if (!items.length) return 'No prior lookups recorded.'
+    const now = Date.now()
+    const day = 24 * 60 * 60 * 1000
+    const buckets = { week: 0, month: 0, quarter: 0, older: 0 }
+    const lengths: number[] = []
+    const recent: string[] = []
+    for (const item of items) {
+        const age = now - item.createdAt
+        if (age < 7 * day) buckets.week += 1
+        else if (age < 30 * day) buckets.month += 1
+        else if (age < 90 * day) buckets.quarter += 1
+        else buckets.older += 1
+        lengths.push(item.text.trim().split(/\s+/).length)
+        if (recent.length < 25) recent.push(item.text.trim())
+    }
+    const avgLen = lengths.length ? Math.round((lengths.reduce((a, b) => a + b, 0) / lengths.length) * 10) / 10 : 0
+    const longish = items
+        .filter((i) => i.text.trim().split(/\s+/).length >= 3)
+        .slice(0, 8)
+        .map((i) => i.text.trim())
+    return [
+        `Recent counts — 7d:${buckets.week}, 30d:${buckets.month}, 90d:${buckets.quarter}, older:${buckets.older}.`,
+        `Average lookup length: ${avgLen} words.`,
+        recent.length ? `Sample recent lookups: ${recent.slice(0, 12).join('; ')}` : '',
+        longish.length ? `Sample multi-word lookups: ${longish.join('; ')}` : '',
+    ]
+        .filter(Boolean)
+        .join('\n')
+}
+
+function buildPickerPrompts(ctx: AxContext, historyHint: string, targetLang: string) {
+    const role = `You assist an English learner. The user can read but sometimes wants to look up a word, phrase, or sentence that appears in the screen reader text in front of them. Their typical lookup history reveals their level. Pick at most 4 candidates that they are most likely to want translated next. Prefer the rarest/most novel content over common words they would already know.
+
+Target language for translation is ${targetLang}.
+
+Output format — exactly one candidate per line, no preamble, no JSON, no markdown:
+TYPE :: TEXT :: REASON
+Where TYPE is one of word, phrase, sentence. TEXT is the exact span as it appears on screen (do not paraphrase). REASON is one short clause explaining why this candidate matters to this user.
+
+Order candidates from most likely to least likely. Output 1–4 lines.`
+
+    const userCtx = summarizeContext(ctx)
+    const command = `User lookup history fingerprint:\n${historyHint}\n\nScreen context:\n${userCtx}\n\nReturn candidates now.`
+    return { rolePrompt: role, commandPrompt: command }
+}
+
+function parseCandidates(stream: string): Candidate[] {
+    const out: Candidate[] = []
+    const lines = stream.split('\n')
+    for (const raw of lines) {
+        const line = raw.trim()
+        if (!line) continue
+        const m = line.match(/^([0-9]+[).\s]+)?(word|phrase|sentence)\s*::\s*(.+?)\s*::\s*(.+)$/i)
+        if (!m) continue
+        const type = m[2].toLowerCase() as CandidateType
+        const text = m[3].trim().replace(/^"|"$/g, '').replace(/^'|'$/g, '')
+        const reason = m[4].trim()
+        if (text && reason) out.push({ text, type, reason })
+    }
+    return out
+}
+
+export function QuickTranslator({ fetchContext, onClose, onHide }: QuickTranslatorProps) {
+    const { t } = useTranslation()
+    const { theme, themeType } = useTheme()
+    const { settings } = useSettings()
+    const styles = useStyles({ theme, themeType })
+
+    const [ctx, setCtx] = useState<AxContext | null>(null)
+    const [candidates, setCandidates] = useState<Candidate[]>([])
+    const [activeIndex, setActiveIndex] = useState(0)
+    const [pickerLoading, setPickerLoading] = useState(false)
+    const [pickerError, setPickerError] = useState('')
+    const [translation, setTranslation] = useState('')
+    const [translating, setTranslating] = useState(false)
+    const [translateError, setTranslateError] = useState('')
+    const [wideUsed, setWideUsed] = useState(false)
+
+    const pickerAbortRef = useRef<AbortController | null>(null)
+    const translateAbortRef = useRef<AbortController | null>(null)
+
+    const targetLang = settings.defaultTargetLanguage || 'en'
+
+    const runPicker = useCallback(
+        async (wide: boolean) => {
+            pickerAbortRef.current?.abort()
+            translateAbortRef.current?.abort()
+            const controller = new AbortController()
+            pickerAbortRef.current = controller
+
+            setPickerLoading(true)
+            setPickerError('')
+            setCandidates([])
+            setTranslation('')
+            setTranslateError('')
+            setActiveIndex(0)
+
+            try {
+                const [context, history] = await Promise.all([
+                    fetchContext(wide),
+                    historyInternalService.list({ limit: 200 }),
+                ])
+                if (controller.signal.aborted) return
+                setCtx(context)
+                const hasContext =
+                    context.focusedText.trim() ||
+                    context.hoveredText.trim() ||
+                    context.selectedText.trim() ||
+                    context.paragraphs.length
+                if (!hasContext) {
+                    setPickerLoading(false)
+                    setPickerError(t('Unable to read text from the foreground app.'))
+                    return
+                }
+                const historyHint = summarizeHistory(history.map((h) => ({ text: h.text, createdAt: h.createdAt })))
+                const { rolePrompt, commandPrompt } = buildPickerPrompts(context, historyHint, targetLang)
+                const engine = getEngine(settings.provider)
+                let buffer = ''
+                let parsed: Candidate[] = []
+                let triggeredTranslate = false
+                await engine.sendMessage({
+                    rolePrompt,
+                    commandPrompt,
+                    signal: controller.signal,
+                    onMessage: async (msg) => {
+                        if (controller.signal.aborted) return
+                        if (msg.isFullText) {
+                            buffer = msg.content
+                        } else {
+                            buffer += msg.content
+                        }
+                        const next = parseCandidates(buffer)
+                        if (next.length !== parsed.length) {
+                            parsed = next
+                            setCandidates(next)
+                            if (!triggeredTranslate && next.length > 0) {
+                                triggeredTranslate = true
+                                runTranslateRef.current?.(next[0])
+                            }
+                        }
+                    },
+                    onError: (err) => {
+                        if (controller.signal.aborted) return
+                        setPickerError(err)
+                        setPickerLoading(false)
+                    },
+                    onFinished: () => {
+                        if (controller.signal.aborted) return
+                        setPickerLoading(false)
+                        const finalCandidates = parseCandidates(buffer)
+                        if (finalCandidates.length === 0) {
+                            setPickerError(t('Could not extract candidates from the screen text.'))
+                        }
+                    },
+                })
+            } catch (err) {
+                if (controller.signal.aborted) return
+                setPickerError(err instanceof Error ? err.message : String(err))
+                setPickerLoading(false)
+            }
+        },
+        [fetchContext, settings.provider, targetLang, t]
+    )
+
+    const runTranslate = useCallback(
+        async (candidate: Candidate) => {
+            translateAbortRef.current?.abort()
+            const controller = new AbortController()
+            translateAbortRef.current = controller
+            setTranslating(true)
+            setTranslateError('')
+            setTranslation('')
+
+            try {
+                const action = await actionInternalService.getByMode('translate')
+                if (!action) {
+                    setTranslating(false)
+                    setTranslateError(t('No translate action found.'))
+                    return
+                }
+                const sourceLang = await detectLang(candidate.text)
+                await translate({
+                    text: candidate.text,
+                    detectFrom: sourceLang,
+                    detectTo: targetLang as LangCode,
+                    mode: 'translate',
+                    action,
+                    signal: controller.signal,
+                    onMessage: async (msg) => {
+                        if (controller.signal.aborted) return
+                        if (msg.role) return
+                        setTranslation((prev) => (msg.isFullText ? msg.content : prev + msg.content))
+                    },
+                    onError: (err) => {
+                        if (controller.signal.aborted) return
+                        setTranslateError(err)
+                        setTranslating(false)
+                    },
+                    onFinish: () => {
+                        if (controller.signal.aborted) return
+                        setTranslating(false)
+                    },
+                })
+            } catch (err) {
+                if (controller.signal.aborted) return
+                setTranslateError(err instanceof Error ? err.message : String(err))
+                setTranslating(false)
+            }
+        },
+        [targetLang, t]
+    )
+
+    const runTranslateRef = useRef(runTranslate)
+    useEffect(() => {
+        runTranslateRef.current = runTranslate
+    }, [runTranslate])
+
+    useEffect(() => {
+        runPicker(false)
+        return () => {
+            pickerAbortRef.current?.abort()
+            translateAbortRef.current?.abort()
+        }
+    }, [runPicker])
+
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onHide()
+            }
+        }
+        document.addEventListener('keydown', handler)
+        return () => document.removeEventListener('keydown', handler)
+    }, [onHide])
+
+    const onSelectCandidate = useCallback(
+        (index: number) => {
+            setActiveIndex(index)
+            const c = candidates[index]
+            if (c) runTranslate(c)
+        },
+        [candidates, runTranslate]
+    )
+
+    const onExpandContext = useCallback(() => {
+        setWideUsed(true)
+        runPicker(true)
+    }, [runPicker])
+
+    const hostLabel = ctx?.appName ?? ''
+
+    const activeCandidate = candidates[activeIndex]
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.header} data-tauri-drag-region>
+                <div className={styles.brand}>
+                    <span className={styles.dot} />
+                    <span className={styles.title}>{t('Quick Translator')}</span>
+                    {hostLabel && (
+                        <>
+                            <span className={styles.titleSeparator}>·</span>
+                            <span className={styles.titleHost} title={hostLabel}>
+                                {hostLabel}
+                            </span>
+                        </>
+                    )}
+                </div>
+                <button className={styles.closeBtn} onClick={onClose} title={t('Close')}>
+                    <RxCross2 size={13} />
+                </button>
+            </div>
+            <div className={styles.candidatesArea}>
+                {pickerLoading && candidates.length === 0 && (
+                    <div className={styles.candidatesEmpty}>
+                        <SpinnerIcon size={12} />
+                        <span>{t('Detecting what you are reading…')}</span>
+                    </div>
+                )}
+                {!pickerLoading && pickerError && candidates.length === 0 && (
+                    <div className={styles.candidatesEmpty}>
+                        <span>{pickerError}</span>
+                    </div>
+                )}
+                {candidates.map((c, idx) => (
+                    <button
+                        key={`${c.text}-${idx}`}
+                        className={`${styles.chip} ${idx === activeIndex ? styles.chipActive : ''}`}
+                        onClick={() => onSelectCandidate(idx)}
+                        title={c.reason}
+                    >
+                        <span className={styles.chipKind}>{c.type}</span>
+                        <span className={styles.chipText}>{c.text}</span>
+                    </button>
+                ))}
+            </div>
+            {(candidates.length > 0 || translating || translation || translateError) && (
+                <div className={styles.divider} />
+            )}
+            <div className={styles.translationArea} style={{ fontSize: settings.fontSize }}>
+                {translateError && <div className={styles.errorMsg}>{translateError}</div>}
+                {!translation && translating && (
+                    <div className={styles.translationPlaceholder}>
+                        <SpinnerIcon size={12} />
+                        <span>
+                            {activeCandidate
+                                ? t('Translating “{{text}}”…', { text: activeCandidate.text })
+                                : t('Translating…')}
+                        </span>
+                    </div>
+                )}
+                {translation && (
+                    <div>
+                        <Markdown>{translation}</Markdown>
+                        {translating && <span className={styles.caret} />}
+                    </div>
+                )}
+            </div>
+            <div className={styles.footer}>
+                <div className={styles.footerHint}>
+                    <span className={styles.kbd}>esc</span>
+                    <span>{t('close')}</span>
+                    {ctx?.truncated && (
+                        <>
+                            <span style={{ opacity: 0.4, margin: '0 4px' }}>·</span>
+                            <span>{t('context truncated')}</span>
+                        </>
+                    )}
+                </div>
+                <div style={{ display: 'flex', gap: 2 }}>
+                    <button className={styles.actionBtn} onClick={onExpandContext} disabled={pickerLoading || wideUsed}>
+                        {wideUsed ? t('wider context') : t('use wider context')}
+                    </button>
+                    <button className={styles.actionBtn} onClick={() => runPicker(wideUsed)} disabled={pickerLoading}>
+                        {t('re-detect')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -3486,6 +3486,18 @@ export function InnerSettings({
                         >
                             <HotkeyRecorder onBlur={onBlur} testId='ocr-hotkey-recorder' />
                         </FormItem>
+                        <FormItem
+                            style={{
+                                display: isDesktopApp ? 'block' : 'none',
+                            }}
+                            name='quickTranslatorHotkey'
+                            label={t('Quick Translator Hotkey')}
+                            caption={t(
+                                'Open a non-activating panel that auto-detects the word or sentence you are reading.'
+                            )}
+                        >
+                            <HotkeyRecorder onBlur={onBlur} testId='quick-translator-hotkey-recorder' />
+                        </FormItem>
                     </div>
                 </div>
                 <div

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -81,6 +81,7 @@ export interface ISettings {
     hotkey?: string
     displayWindowHotkey?: string
     ocrHotkey?: string
+    quickTranslatorHotkey?: string
     writingTargetLanguage: string
     writingHotkey?: string
     writingNewlineHotkey?: string

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -68,6 +68,7 @@ const settingKeys: Record<keyof ISettings, number> = {
     hotkey: 1,
     displayWindowHotkey: 1,
     ocrHotkey: 1,
+    quickTranslatorHotkey: 1,
     writingTargetLanguage: 1,
     writingHotkey: 1,
     writingNewlineHotkey: 1,

--- a/src/tauri/App.tsx
+++ b/src/tauri/App.tsx
@@ -8,6 +8,8 @@ import { UpdaterWindow } from './windows/UpdaterWindow'
 import { ScreenshotWindow } from './windows/ScreenshotWindow'
 import { HistoryWindow } from './windows/HistoryWindow'
 import { InlineLookupWindow } from './windows/InlineLookupWindow'
+import { QuickTranslatorWindow } from './windows/QuickTranslatorWindow'
+import { WritingIndicatorWindow } from './windows/WritingIndicatorWindow'
 
 const windowsMap: Record<string, typeof TranslatorWindow> = {
     translator: TranslatorWindow,
@@ -18,6 +20,8 @@ const windowsMap: Record<string, typeof TranslatorWindow> = {
     screenshot: ScreenshotWindow,
     history: HistoryWindow,
     inline_lookup: InlineLookupWindow,
+    quick_translator: QuickTranslatorWindow,
+    writing_indicator: WritingIndicatorWindow,
 }
 
 export function App() {

--- a/src/tauri/bindings.ts
+++ b/src/tauri/bindings.ts
@@ -44,6 +44,20 @@ export const commands = {
     async finishWriting(): Promise<void> {
         await TAURI_INVOKE('finish_writing')
     },
+    async showWritingIndicator(targetLanguage: string): Promise<void> {
+        await TAURI_INVOKE('show_writing_indicator', { targetLanguage })
+    },
+    async hideWritingIndicator(): Promise<void> {
+        await TAURI_INVOKE('hide_writing_indicator')
+    },
+    /**
+     * Returns the target language of the currently-showing indicator, if any.
+     * React calls this on mount to recover from the case where the
+     * `writing-indicator-start` event was emitted before its listener was wired.
+     */
+    async getWritingIndicatorPendingLang(): Promise<string | null> {
+        return await TAURI_INVOKE('get_writing_indicator_pending_lang')
+    },
     async insertTranslationIntoPreviousInput(text: string): Promise<Result<null, string>> {
         try {
             return { status: 'ok', data: await TAURI_INVOKE('insert_translation_into_previous_input', { text }) }
@@ -69,6 +83,18 @@ export const commands = {
     },
     async showInlineLookupWindowCommand(): Promise<void> {
         await TAURI_INVOKE('show_inline_lookup_window_command')
+    },
+    async showQuickTranslatorWindowCommand(): Promise<void> {
+        await TAURI_INVOKE('show_quick_translator_window_command')
+    },
+    async hideQuickTranslatorWindow(): Promise<void> {
+        await TAURI_INVOKE('hide_quick_translator_window')
+    },
+    async readAxContextNarrow(): Promise<AxContext> {
+        return await TAURI_INVOKE('read_ax_context_narrow')
+    },
+    async readAxContextWide(): Promise<AxContext> {
+        return await TAURI_INVOKE('read_ax_context_wide')
     },
     async startOcr(): Promise<void> {
         await TAURI_INVOKE('start_ocr')
@@ -101,6 +127,19 @@ export const events = __makeEvents__<{
 
 /** user-defined types **/
 
+export type AxContext = {
+    focusedText: string
+    focusedRole: string
+    selectedText: string
+    hoveredText: string
+    hoveredRole: string
+    appName: string
+    appBundleId: string
+    mouseX: number
+    mouseY: number
+    paragraphs: string[]
+    truncated: boolean
+}
 export type CheckUpdateEvent = null
 export type CheckUpdateResultEvent = UpdateResult
 export type ConfigUpdatedEvent = null

--- a/src/tauri/utils.ts
+++ b/src/tauri/utils.ts
@@ -97,6 +97,29 @@ export async function bindOCRHotkey(oldOCRHotKey?: string) {
     })
 }
 
+export async function bindQuickTranslatorHotkey(oldHotKey?: string) {
+    if (oldHotKey && !isMissingNormalKey(oldHotKey) && (await isRegistered(oldHotKey))) {
+        await unregister(oldHotKey)
+    }
+    const settings = await getSettings()
+    if (!settings.quickTranslatorHotkey) return
+    if (isMissingNormalKey(settings.quickTranslatorHotkey)) {
+        sendNotification({
+            title: 'Cannot bind hotkey',
+            body: `Hotkey must contain at least one normal key: ${settings.quickTranslatorHotkey}`,
+        })
+        return
+    }
+    if (await isRegistered(settings.quickTranslatorHotkey)) {
+        await unregister(settings.quickTranslatorHotkey)
+    }
+    await register(settings.quickTranslatorHotkey, () => {
+        return commands.showQuickTranslatorWindowCommand()
+    }).then(() => {
+        console.log('quick translator hotkey registered')
+    })
+}
+
 export async function bindWritingHotkey(oldWritingHotKey?: string) {
     if (oldWritingHotKey && !isMissingNormalKey(oldWritingHotKey) && (await isRegistered(oldWritingHotKey))) {
         await unregister(oldWritingHotKey)
@@ -125,5 +148,6 @@ export function onSettingsSave(oldSettings: ISettings) {
     bindHotkey(oldSettings.hotkey)
     bindDisplayWindowHotkey(oldSettings.displayWindowHotkey)
     bindOCRHotkey(oldSettings.ocrHotkey)
+    bindQuickTranslatorHotkey(oldSettings.quickTranslatorHotkey)
     bindWritingHotkey(oldSettings.writingHotkey)
 }

--- a/src/tauri/windows/QuickTranslatorWindow.tsx
+++ b/src/tauri/windows/QuickTranslatorWindow.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'react'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { Client as Styletron } from 'styletron-engine-atomic'
+import { Provider as StyletronProvider } from 'styletron-react'
+import { BaseProvider } from 'baseui-sd'
+import { ErrorBoundary } from 'react-error-boundary'
+import { ErrorFallback } from '../../common/components/ErrorFallback'
+import { GlobalSuspense } from '../../common/components/GlobalSuspense'
+import { QuickTranslator, AxContext } from '../../common/components/QuickTranslator'
+import { setupAnalysis } from '../../common/analysis'
+import { useTheme } from '../../common/hooks/useTheme'
+import { PREFIX } from '../../common/constants'
+import { commands } from '../bindings'
+import '../../common/i18n.js'
+
+const engine = new Styletron({
+    prefix: `${PREFIX}-styletron-`,
+})
+
+export function QuickTranslatorWindow() {
+    const { theme } = useTheme()
+
+    useEffect(() => {
+        setupAnalysis()
+        document.body.style.margin = '0'
+        document.body.style.background = 'transparent'
+    }, [])
+
+    const fetchContext = useCallback(async (wide: boolean): Promise<AxContext> => {
+        const ctx = wide ? await commands.readAxContextWide() : await commands.readAxContextNarrow()
+        return ctx as AxContext
+    }, [])
+
+    const hide = useCallback(() => {
+        commands.hideQuickTranslatorWindow()
+    }, [])
+
+    const [tick, setTick] = useState(0)
+
+    useEffect(() => {
+        let unlisten: UnlistenFn | undefined
+        ;(async () => {
+            unlisten = await listen('quick-translator-shown', () => {
+                setTick((n) => n + 1)
+            })
+        })()
+        return () => {
+            unlisten?.()
+        }
+    }, [])
+
+    return (
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <StyletronProvider value={engine}>
+                <BaseProvider theme={theme}>
+                    <GlobalSuspense>
+                        <QuickTranslator key={tick} fetchContext={fetchContext} onClose={hide} onHide={hide} />
+                    </GlobalSuspense>
+                </BaseProvider>
+            </StyletronProvider>
+        </ErrorBoundary>
+    )
+}

--- a/src/tauri/windows/TranslatorWindow.tsx
+++ b/src/tauri/windows/TranslatorWindow.tsx
@@ -2,7 +2,14 @@ import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
 import { Translator } from '../../common/components/Translator'
 import { Client as Styletron } from 'styletron-engine-atomic'
 import { listen, type Event, type UnlistenFn } from '@tauri-apps/api/event'
-import { bindDisplayWindowHotkey, bindHotkey, bindOCRHotkey, bindWritingHotkey, onSettingsSave } from '../utils'
+import {
+    bindDisplayWindowHotkey,
+    bindHotkey,
+    bindOCRHotkey,
+    bindQuickTranslatorHotkey,
+    bindWritingHotkey,
+    onSettingsSave,
+} from '../utils'
 import { v4 as uuidv4 } from 'uuid'
 import { PREFIX } from '../../common/constants'
 import { translate } from '../../common/translate'
@@ -110,19 +117,42 @@ export function TranslatorWindow() {
         let unlisten: UnlistenFn | undefined
         ;(async () => {
             unlisten = await listen('writing-text', async (event: Event<string>) => {
+                // eslint-disable-next-line no-console
+                console.log('[writing] received writing-text event', {
+                    payloadLen: event.payload?.length ?? 0,
+                    writingTargetLanguage: settings?.writingTargetLanguage,
+                })
                 const ensureFinish = () => {
                     writingQueue.current.push(0)
                     writing()
                 }
                 if (!settings?.writingTargetLanguage) {
+                    // eslint-disable-next-line no-console
+                    console.warn(
+                        '[writing] bailing: settings.writingTargetLanguage is not set — ' +
+                            'open Settings → Writing → Target language and pick one'
+                    )
                     commands.finishWriting().catch(console.error)
                     return
                 }
                 const inputText = event.payload
                 if (!inputText) {
+                    // eslint-disable-next-line no-console
+                    console.warn('[writing] bailing: empty input text')
                     commands.finishWriting().catch(console.error)
                     return
                 }
+
+                // Show the floating writing-indicator HUD anchored below the
+                // user's input. Rust's `finish_writing` will emit the matching
+                // "writing-indicator-finish" event to tear it down — so error
+                // and success paths both go through `enqueueFinish`.
+                // eslint-disable-next-line no-console
+                console.log('[writing] calling showWritingIndicator(', settings.writingTargetLanguage, ')')
+                commands.showWritingIndicator(settings.writingTargetLanguage).catch((err) => {
+                    // eslint-disable-next-line no-console
+                    console.error('[writing] showWritingIndicator failed', err)
+                })
 
                 const controller = new AbortController()
                 const { signal } = controller
@@ -226,6 +256,7 @@ export function TranslatorWindow() {
         bindHotkey()
         bindDisplayWindowHotkey()
         bindOCRHotkey()
+        bindQuickTranslatorHotkey()
         bindWritingHotkey()
     }, [])
 

--- a/src/tauri/windows/WritingIndicatorWindow.tsx
+++ b/src/tauri/windows/WritingIndicatorWindow.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useRef, useState } from 'react'
+import { listen, type Event, type UnlistenFn } from '@tauri-apps/api/event'
+import { commands } from '../bindings'
+
+// Floating "translating" HUD anchored just below the input the user triggered
+// writing on. The window itself uses macOS HudWindow vibrancy (applied in
+// Rust); this React layer renders only the foreground content (icon + label +
+// pulsing dots, with a check morph on done). Keep the layer minimal so the
+// native frosted material does the visual heavy lifting.
+
+type StartPayload = { targetLanguage?: string }
+
+const PANEL_STYLE: React.CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    padding: '0 14px',
+    pointerEvents: 'none',
+    color: 'rgba(255, 255, 255, 0.92)',
+    // SF Pro on macOS → "-apple-system" picks SF Pro Text / Display per size.
+    fontFamily:
+        '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+    // Subtle top inner highlight & bottom shadow that AppKit HUDs have.
+    boxShadow: 'inset 0 0.5px 0 rgba(255, 255, 255, 0.10), inset 0 -0.5px 0 rgba(0, 0, 0, 0.20)',
+    borderRadius: 14,
+    overflow: 'hidden',
+}
+
+const ROW_STYLE: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 9,
+    width: '100%',
+    fontSize: 12.5,
+    fontWeight: 500,
+    letterSpacing: 0.05,
+    lineHeight: 1,
+    // Smooth content fade independent of the OS window-show.
+    transition: 'opacity 260ms cubic-bezier(.4,0,.2,1), transform 320ms cubic-bezier(.16,1,.3,1)',
+    willChange: 'opacity, transform',
+}
+
+const LABEL_STYLE: React.CSSProperties = {
+    flex: 1,
+    minWidth: 0,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    color: 'rgba(255, 255, 255, 0.88)',
+}
+
+const DOTS_WRAPPER: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 3,
+    marginLeft: 2,
+}
+
+const ICON_WRAPPER: React.CSSProperties = {
+    width: 14,
+    height: 14,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: '0 0 14px',
+}
+
+function ensureKeyframes() {
+    const id = '__writing_indicator_kf__'
+    if (document.getElementById(id)) return
+    const style = document.createElement('style')
+    style.id = id
+    style.textContent = `
+@keyframes wi-dot-pulse {
+    0%, 80%, 100% { opacity: 0.35; transform: scale(0.82); }
+    40%           { opacity: 1;    transform: scale(1.04); }
+}
+@keyframes wi-pen-wobble {
+    0%, 100% { transform: translateY(0)    rotate(-3deg); }
+    50%      { transform: translateY(-0.8px) rotate(4deg); }
+}
+@keyframes wi-check-pop {
+    0%   { opacity: 0; transform: scale(0.4) rotate(-12deg); }
+    60%  { opacity: 1; transform: scale(1.08) rotate(2deg); }
+    100% { opacity: 1; transform: scale(1) rotate(0deg); }
+}
+`
+    document.head.appendChild(style)
+}
+
+function languageLabel(lang: string | undefined): string {
+    if (!lang || !lang.trim()) return 'Translating'
+    return `Translating · ${lang}`
+}
+
+const PenIcon = () => (
+    <svg
+        width='13'
+        height='13'
+        viewBox='0 0 16 16'
+        fill='none'
+        style={{
+            display: 'block',
+            animation: 'wi-pen-wobble 1.8s ease-in-out infinite',
+            transformOrigin: '8px 12px',
+        }}
+    >
+        {/* Slim line-art fountain pen tip — minimal SF-Symbols feel. */}
+        <path
+            d='M2.4 13.6 L4.6 12.9 L13.0 4.5 L11.5 3.0 L3.1 11.4 L2.4 13.6 Z'
+            stroke='rgba(255,255,255,0.88)'
+            strokeWidth='1.1'
+            strokeLinejoin='round'
+            strokeLinecap='round'
+            fill='rgba(255,255,255,0.04)'
+        />
+        <path d='M10.4 4.1 L11.9 5.6' stroke='rgba(255,255,255,0.88)' strokeWidth='1.1' strokeLinecap='round' />
+    </svg>
+)
+
+const CheckIcon = () => (
+    <svg
+        width='13'
+        height='13'
+        viewBox='0 0 16 16'
+        fill='none'
+        style={{
+            display: 'block',
+            animation: 'wi-check-pop 320ms cubic-bezier(.2,1.4,.4,1) both',
+        }}
+    >
+        <path
+            d='M3.2 8.4 L6.4 11.6 L12.8 4.8'
+            stroke='rgba(120, 220, 160, 1)'
+            strokeWidth='1.6'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+        />
+    </svg>
+)
+
+const PulsingDots = () => (
+    <span style={DOTS_WRAPPER} aria-hidden>
+        {[0, 1, 2].map((i) => (
+            <span
+                key={i}
+                style={{
+                    width: 3,
+                    height: 3,
+                    borderRadius: '50%',
+                    background: 'rgba(255, 255, 255, 0.75)',
+                    animation: 'wi-dot-pulse 1.3s ease-in-out infinite',
+                    animationDelay: `${i * 140}ms`,
+                }}
+            />
+        ))}
+    </span>
+)
+
+export function WritingIndicatorWindow() {
+    const [lang, setLang] = useState<string>('')
+    const [done, setDone] = useState(false)
+    // Render content immediately on mount. The native window itself is hidden
+    // by default and Rust only `window.show()`s during an active writing
+    // trigger, so the panel only reaches the screen during real work.
+    const [visible, setVisible] = useState(true)
+    const fadeTimer = useRef<number | null>(null)
+
+    useEffect(() => {
+        ensureKeyframes()
+        document.body.style.margin = '0'
+        document.body.style.background = 'transparent'
+        document.documentElement.style.background = 'transparent'
+        document.documentElement.style.colorScheme = 'dark'
+    }, [])
+
+    useEffect(() => {
+        let off1: UnlistenFn | undefined
+        let off2: UnlistenFn | undefined
+
+        const startWith = (l: string) => {
+            if (fadeTimer.current) {
+                window.clearTimeout(fadeTimer.current)
+                fadeTimer.current = null
+            }
+            setLang(l)
+            setDone(false)
+            setVisible(true)
+        }
+
+        ;(async () => {
+            off1 = await listen('writing-indicator-start', (e: Event<StartPayload>) => {
+                // eslint-disable-next-line no-console
+                console.log('[indicator] received writing-indicator-start', e.payload)
+                startWith(e.payload?.targetLanguage ?? '')
+            })
+            off2 = await listen('writing-indicator-finish', () => {
+                // eslint-disable-next-line no-console
+                console.log('[indicator] received writing-indicator-finish')
+                // Flash the check, then fade. Rust hides the OS window ~700ms
+                // from emit, so we start the fade at 350ms — it completes
+                // before the window disappears, giving a smooth exit instead
+                // of a snap.
+                setDone(true)
+                fadeTimer.current = window.setTimeout(() => {
+                    setVisible(false)
+                    fadeTimer.current = null
+                }, 350)
+            })
+
+            // Race recovery: poll for a pending show that may have been emitted
+            // before the listener above was wired up.
+            try {
+                const pending = await commands.getWritingIndicatorPendingLang()
+                if (pending) {
+                    // eslint-disable-next-line no-console
+                    console.log('[indicator] recovered pending start from backend:', pending)
+                    startWith(pending)
+                }
+            } catch (err) {
+                // eslint-disable-next-line no-console
+                console.warn('[indicator] getWritingIndicatorPendingLang failed', err)
+            }
+        })()
+
+        return () => {
+            off1?.()
+            off2?.()
+            if (fadeTimer.current) window.clearTimeout(fadeTimer.current)
+        }
+    }, [])
+
+    const row: React.CSSProperties = {
+        ...ROW_STYLE,
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(-2px)',
+    }
+
+    return (
+        <div style={PANEL_STYLE}>
+            <div style={row}>
+                <span style={ICON_WRAPPER}>{done ? <CheckIcon /> : <PenIcon />}</span>
+                <span style={LABEL_STYLE}>{done ? 'Done' : languageLabel(lang)}</span>
+                {!done && <PulsingDots />}
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Why

The writing flow's "Translating..." / "✅" indicator was typed directly into the user's input box and erased with simulated Backspace keystrokes via AppleScript. The Backspace count was a hand-tuned magic number that broke on:

- Grapheme width mismatches — `✍️` = 2 Unicode scalars but 1 grapheme, so `.chars().count()` over-counts by 1 in most fields.
- IME composition, autocomplete, predictive text.
- Any cursor drift between the placeholder being typed and it being erased.

Result: writing regularly **ate real user text**.

## What

### Writing flow rewrite
- **Floating HUD panel** anchored just below the focused input (via AX position+size; falls back to mouse). Native macOS HudWindow vibrancy, SVG pen icon with subtle nib wobble, `Translating · <lang>` label, pulsing dots; morphs to a green check on finish, then fades.
- **AX-first read** — `kAXSelectedTextAttribute` → `kAXValueAttribute`. Falls back to select-all + clipboard only when AX returns nothing (Electron apps without AX, custom widgets, etc.). No more Cmd+A flash + clipboard hijack on every trigger.
- **Zero Backspace / arrow keys** in the writing flow. Selection mode types over the live selection; whole-input mode does select-all + retype. The old incremental + invisible-fingerprint re-edit path is removed — re-triggering on already-translated text retypes the whole content instead of patching diffs.
- **Rust-authoritative hide** (700 ms after `finish_writing`) so the HUD can't stick on screen if the React listener races.

### Plumbing
- New `writing_indicator` window pre-created on the AppKit main thread.
- New Tauri commands: `show_writing_indicator`, `hide_writing_indicator`, `get_writing_indicator_pending_lang`.
- New utils: `get_writing_anchor_rect`, `get_selected_text_via_ax`, `get_focused_text_via_ax`, `get_focused_element_frame_by_ax`.

### Bundled WIP
This PR also includes in-progress work for the **quick translator panel + AX context** (`ax_context.rs`, `QuickTranslatorWindow`, hotkey wiring, settings) that was already in the working tree. Both bodies of work share the same AX/window infrastructure.

## Verification

Live dev logs after the change:
```
[writing] trigger
[writing] read full value via AX (2 chars)     ← clean AX read, no clipboard
[indicator] show_writing_indicator(target_language="en")
[indicator] anchor (logical pts): (2329,1085,799,21)
[indicator] emitted writing-indicator-start
[writing] finish_writing called
[writing] emitted writing-indicator-finish
[writing] indicator window hidden by Rust authoritative path
```

- `cargo check --no-default-features` — 0 errors
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm exec eslint` — 0 errors

## Trade-off

Dropping the incremental re-edit path means re-triggering writing on already-translated text now retypes the whole field instead of surgically patching diffs. This is the only way to guarantee zero over-deletion, and matches user-requested scope ("Full fix — drop incremental").