### PR TITLE
feat: keyboard shortcut for "Insert into previous input"

### DIFF
--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -1622,7 +1622,6 @@ function InnerTranslator(props: IInnerTranslatorProps) {
         setActionStr('Stopped')
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const handleInsertTranslatedText = useCallback(async () => {
         if (!translatedText || !isTauri()) {
             return
@@ -1642,6 +1641,33 @@ function InnerTranslator(props: IInnerTranslatorProps) {
             })
         }
     }, [t, translatedText])
+
+    // Window-level keyboard shortcut for "Insert into previous input"
+    // — ⇧⌘↩ on macOS, Ctrl+Shift+Enter elsewhere. Mirrors the toolbar button.
+    useEffect(() => {
+        if (!isTauri()) {
+            return
+        }
+        const handler = (e: KeyboardEvent) => {
+            const accel = isMacOS ? e.metaKey : e.ctrlKey
+            if (!accel || !e.shiftKey) {
+                return
+            }
+            if (e.key !== 'Enter') {
+                return
+            }
+            if (!translatedText) {
+                return
+            }
+            e.preventDefault()
+            e.stopPropagation()
+            handleInsertTranslatedText()
+        }
+        document.addEventListener('keydown', handler)
+        return () => {
+            document.removeEventListener('keydown', handler)
+        }
+    }, [translatedText, handleInsertTranslatedText])
 
     const [isScrolledToTop, setIsScrolledToTop] = useState(false)
     const [isScrolledToBottom, setIsScrolledToBottom] = useState(false)
@@ -2544,7 +2570,9 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                                                 )}
                                                 {isTauri() && (
                                                     <Tooltip
-                                                        content={t('Insert into previous input')}
+                                                        content={`${t('Insert into previous input')} (${
+                                                            isMacOS ? '⇧⌘↩' : 'Ctrl+Shift+Enter'
+                                                        })`}
                                                         placement='bottom'
                                                     >
                                                         <div


### PR DESCRIPTION
## Summary

Adds a window-level keyboard shortcut to trigger **Insert into previous input** from the Translator window — equivalent to clicking the existing toolbar button, but reachable without the mouse.

- macOS: `⇧⌘↩`
- Windows / Linux: `Ctrl+Shift+Enter`

Only active when:
- Running in the Tauri desktop app (`isTauri()`)
- A translation has been rendered (`translatedText` non-empty)

The button's tooltip is updated to surface the shortcut so users discover it without reading release notes.

No new dependencies, no new Tauri commands, no settings field — the shortcut reuses the existing `insertTranslationIntoPreviousInput` command.

Addresses the first half of the request in #1876.

## Test plan

- [ ] Open the Tauri app, translate any text, press `⇧⌘↩` (macOS) → translation appears in whatever input was focused before the Translator window opened
- [ ] Same on Windows / Linux using `Ctrl+Shift+Enter`
- [ ] Hover the insert button → tooltip shows the shortcut
- [ ] Pressing the shortcut while there is no translation does nothing
- [ ] Pressing the shortcut in the browser extension build is a no-op