### PR TITLE
fix: only send reasoning_effort:none to models that support it (#1879)

### DIFF
--- a/src/common/engines/abstract-openai.spec.ts
+++ b/src/common/engines/abstract-openai.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AbstractOpenAI } from './abstract-openai'
 import { IMessageRequest } from './interfaces'
-import { fetchSSE } from '../utils'
+import { fetchSSE, getSettings } from '../utils'
 
 vi.mock('../utils', () => {
     return {
@@ -304,6 +304,72 @@ describe('AbstractOpenAI', () => {
             })
 
             await engine.sendMessage(req)
+        })
+    })
+
+    describe('thinkingEnabled reasoning_effort gating', () => {
+        it('does not inject reasoning_effort:none for non-OpenAI providers (e.g. DeepSeek)', async () => {
+            // Regression test for #1879: `reasoning_effort: 'none'` is only valid for OpenAI
+            // GPT-5.1+ models. Other providers (DeepSeek, etc.) reject it.
+            vi.mocked(getSettings).mockResolvedValueOnce({ thinkingEnabled: false } as never)
+            const engine = new TestOpenAIEngine('deepseek-chat', 'https://api.deepseek.com', '/v1/chat/completions')
+            const { req } = createMessageRequest()
+
+            vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+                const payload = JSON.parse(options.body as string)
+                expect(payload.model).toBe('deepseek-chat')
+                expect(payload.reasoning_effort).toBeUndefined()
+                await options.onMessage(
+                    JSON.stringify({
+                        // eslint-disable-next-line camelcase
+                        choices: [{ delta: {}, finish_reason: 'stop' }],
+                    })
+                )
+            })
+
+            await engine.sendMessage(req)
+            expect(vi.mocked(fetchSSE)).toHaveBeenCalled()
+        })
+
+        it('injects reasoning_effort:none for GPT-5.1+ when thinking is disabled', async () => {
+            vi.mocked(getSettings).mockResolvedValueOnce({ thinkingEnabled: false } as never)
+            const engine = new TestOpenAIEngine('gpt-5.1', 'https://example.com', '/v1/chat/completions')
+            const { req } = createMessageRequest()
+
+            vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+                const payload = JSON.parse(options.body as string)
+                expect(payload.model).toBe('gpt-5.1')
+                expect(payload.reasoning_effort).toBe('none')
+                await options.onMessage(
+                    JSON.stringify({
+                        // eslint-disable-next-line camelcase
+                        choices: [{ delta: {}, finish_reason: 'stop' }],
+                    })
+                )
+            })
+
+            await engine.sendMessage(req)
+            expect(vi.mocked(fetchSSE)).toHaveBeenCalled()
+        })
+
+        it('does not inject reasoning_effort:none for GPT-5.1+ when thinking is enabled', async () => {
+            vi.mocked(getSettings).mockResolvedValueOnce({ thinkingEnabled: true } as never)
+            const engine = new TestOpenAIEngine('gpt-5.1', 'https://example.com', '/v1/chat/completions')
+            const { req } = createMessageRequest()
+
+            vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+                const payload = JSON.parse(options.body as string)
+                expect(payload.reasoning_effort).toBeUndefined()
+                await options.onMessage(
+                    JSON.stringify({
+                        // eslint-disable-next-line camelcase
+                        choices: [{ delta: {}, finish_reason: 'stop' }],
+                    })
+                )
+            })
+
+            await engine.sendMessage(req)
+            expect(vi.mocked(fetchSSE)).toHaveBeenCalled()
         })
     })
 })

--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -178,6 +178,14 @@ export abstract class AbstractOpenAI extends AbstractEngine {
         return { model, stream: true }
     }
 
+    // `reasoning_effort: 'none'` is only a valid value for OpenAI's GPT-5.1+ reasoning models.
+    // AbstractOpenAI is the shared base class for many OpenAI-compatible providers (DeepSeek,
+    // Groq, Moonshot, MiniMax, Ollama, …) whose APIs reject `none`, so this gate keeps the
+    // thinking-disable override from leaking into request bodies that can't accept it.
+    private modelSupportsReasoningEffortNone(model: string): boolean {
+        return /^gpt-5\.[1-9]/.test(model.toLowerCase())
+    }
+
     async sendMessage(req: IMessageRequest): Promise<void> {
         const apiURL = await this.getAPIURL()
         const apiURLPath = await this.getAPIURLPath()
@@ -189,7 +197,7 @@ export abstract class AbstractOpenAI extends AbstractEngine {
         const isChatAPI = await this.isChatAPI()
         const body = await this.getBaseRequestBody(model)
         const settings = await getSettings()
-        if (!settings.thinkingEnabled) {
+        if (!settings.thinkingEnabled && this.modelSupportsReasoningEffortNone(model)) {
             body['reasoning_effort'] = 'none'
         }
         if (useResponsesAPI) {


### PR DESCRIPTION
## Problem

Fixes #1879.

In `0.6.16`, the `thinkingEnabled` feature (#1866) added this to `AbstractOpenAI.sendMessage`:

```ts
if (!settings.thinkingEnabled) {
    body['reasoning_effort'] = 'none'
}
```

`AbstractOpenAI` is the **shared base class for all OpenAI-compatible engines** (DeepSeek, Groq, Moonshot, MiniMax, Ollama, Azure, …). But `reasoning_effort: 'none'` is only a valid value for OpenAI's GPT-5.1+ models. Since `thinkingEnabled` defaults to `false`, every DeepSeek (and similar) request started shipping `reasoning_effort: 'none'`, which the provider rejected:

```
Failed to deserialize the JSON body into the target type: reasoning_effort:
unknown variant `none`, expected one of `high`, `low`, `medium`, `max`, `xhigh`
```

This broke translation out of the box for all non-OpenAI providers after upgrading to 0.6.16.

## Fix

Gate the override behind `modelSupportsReasoningEffortNone(model)` (`^gpt-5\.[1-9]`), so `'none'` is only injected for models that actually accept it. Other providers' request bodies are left untouched.

## Tests

Added 3 regression tests:
- DeepSeek does **not** receive `reasoning_effort: 'none'`
- GPT-5.1 **does** receive `'none'` when thinking is disabled
- GPT-5.1 does **not** receive it when thinking is enabled

All 14 tests in the suite pass; tsc and eslint are clean.