### PR TITLE
fix: let Ollama disable thinking via reasoning_effort:none (#1881)

### DIFF
--- a/src/common/engines/abstract-openai.spec.ts
+++ b/src/common/engines/abstract-openai.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AbstractOpenAI } from './abstract-openai'
+import { Ollama } from './ollama'
 import { IMessageRequest } from './interfaces'
 import { fetchSSE, getSettings } from '../utils'
 
@@ -360,6 +361,36 @@ describe('AbstractOpenAI', () => {
             vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
                 const payload = JSON.parse(options.body as string)
                 expect(payload.reasoning_effort).toBeUndefined()
+                await options.onMessage(
+                    JSON.stringify({
+                        // eslint-disable-next-line camelcase
+                        choices: [{ delta: {}, finish_reason: 'stop' }],
+                    })
+                )
+            })
+
+            await engine.sendMessage(req)
+            expect(vi.mocked(fetchSSE)).toHaveBeenCalled()
+        })
+
+        it('injects reasoning_effort:none for Ollama so thinking can be disabled (#1881)', async () => {
+            // Regression test for #1881: Ollama / LM Studio servers honor `reasoning_effort: 'none'`
+            // to turn off thinking on hybrid models like Qwen3, so the Ollama engine must keep
+            // sending it even though the conservative base default only allows GPT-5.1+.
+            vi.mocked(getSettings).mockResolvedValue({
+                thinkingEnabled: false,
+                ollamaAPIURL: 'http://localhost:11434',
+                ollamaAPIModel: 'qwen3',
+                ollamaModelLifetimeInMemory: '5m',
+            } as never)
+            const engine = new Ollama()
+            const { req } = createMessageRequest()
+
+            vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+                expect(input).toBe('http://localhost:11434/v1/chat/completions')
+                const payload = JSON.parse(options.body as string)
+                expect(payload.model).toBe('qwen3')
+                expect(payload.reasoning_effort).toBe('none')
                 await options.onMessage(
                     JSON.stringify({
                         // eslint-disable-next-line camelcase

--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -178,11 +178,13 @@ export abstract class AbstractOpenAI extends AbstractEngine {
         return { model, stream: true }
     }
 
-    // `reasoning_effort: 'none'` is only a valid value for OpenAI's GPT-5.1+ reasoning models.
-    // AbstractOpenAI is the shared base class for many OpenAI-compatible providers (DeepSeek,
-    // Groq, Moonshot, MiniMax, Ollama, …) whose APIs reject `none`, so this gate keeps the
-    // thinking-disable override from leaking into request bodies that can't accept it.
-    private modelSupportsReasoningEffortNone(model: string): boolean {
+    // Whether `reasoning_effort: 'none'` may be sent for the given model to disable thinking.
+    // `none` is only a valid value for OpenAI's GPT-5.1+ reasoning models, and strict providers
+    // (e.g. DeepSeek) reject it outright (#1879), so the conservative default only allows it for
+    // GPT-5.1+. AbstractOpenAI is the shared base class for many OpenAI-compatible providers;
+    // lenient or local servers that tolerate the param for any model and honor it for hybrid
+    // reasoning models (e.g. Ollama / LM Studio with Qwen3) override this to return true (#1881).
+    protected supportsReasoningEffortNone(model: string): boolean {
         return /^gpt-5\.[1-9]/.test(model.toLowerCase())
     }
 
@@ -197,7 +199,7 @@ export abstract class AbstractOpenAI extends AbstractEngine {
         const isChatAPI = await this.isChatAPI()
         const body = await this.getBaseRequestBody(model)
         const settings = await getSettings()
-        if (!settings.thinkingEnabled && this.modelSupportsReasoningEffortNone(model)) {
+        if (!settings.thinkingEnabled && this.supportsReasoningEffortNone(model)) {
             body['reasoning_effort'] = 'none'
         }
         if (useResponsesAPI) {

--- a/src/common/engines/ollama.ts
+++ b/src/common/engines/ollama.ts
@@ -44,6 +44,13 @@ export class Ollama extends AbstractOpenAI {
         }
     }
 
+    // Ollama / LM Studio's OpenAI-compatible servers tolerate `reasoning_effort: 'none'` for
+    // non-reasoning models and honor it for hybrid reasoning models (e.g. Qwen3) to turn
+    // thinking off, so always allow it here to disable thinking (regression fix for #1881).
+    protected supportsReasoningEffortNone(): boolean {
+        return true
+    }
+
     async getAPIModel(): Promise<string> {
         const settings = await getSettings()
         if (settings.ollamaAPIModel === CUSTOM_MODEL_ID) {


### PR DESCRIPTION
## Problem

Fixes #1881 (regression introduced by the #1879 fix in #1880).

#1880 gated `reasoning_effort: 'none'` to OpenAI GPT-5.1+ only, to stop strict providers like DeepSeek from rejecting it. But `AbstractOpenAI` is the shared base for **all** OpenAI-compatible engines, so this also stopped **Ollama / LM Studio** from receiving `none` — and those users relied on it to turn off thinking on hybrid models like **Qwen3**. Result: in 0.6.17, disabling `EnableThinking` no longer works for Ollama (the model keeps thinking, slow output).

## Fix

Turn the gate into an overridable `protected supportsReasoningEffortNone(model)` method:

- **Base default** stays conservative — only GPT-5.1+ (keeps DeepSeek and strict OpenAI models from getting a value their API rejects).
- **Ollama** overrides it to always return `true`: its OpenAI-compatible server tolerates the param for non-reasoning models and honors it for hybrid reasoning models (Qwen3) to disable thinking.

This keeps #1879 fixed while restoring the 0.6.16 behavior for Ollama.

## Tests

Added an Ollama regression test (engine sends `reasoning_effort: 'none'` when thinking is disabled). All existing tests still pass (15 total); tsc and eslint clean.