### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/src/common/engines/minimax.ts
+++ b/src/common/engines/minimax.ts
@@ -6,10 +6,9 @@ export class MiniMax extends AbstractOpenAI {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async listModels(_apiKey: string | undefined): Promise<IModel[]> {
         return [
+            { id: 'MiniMax-M3', name: 'MiniMax-M3' },
             { id: 'MiniMax-M2.7', name: 'MiniMax-M2.7' },
             { id: 'MiniMax-M2.7-highspeed', name: 'MiniMax-M2.7-highspeed' },
-            { id: 'MiniMax-M2.5', name: 'MiniMax-M2.5' },
-            { id: 'MiniMax-M2.5-highspeed', name: 'MiniMax-M2.5-highspeed' },
         ]
     }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -224,7 +224,7 @@ export async function getSettings(): Promise<ISettings> {
         settings.ollamaAPIURL = 'http://127.0.0.1:11434'
     }
     if (!settings.miniMaxAPIModel) {
-        settings.miniMaxAPIModel = 'MiniMax-M2.7'
+        settings.miniMaxAPIModel = 'MiniMax-M3'
     }
     if (!settings.groqAPIURL) {
         settings.groqAPIURL = 'https://api.groq.com'


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (`M2.5`/`M2.5-highspeed`)

## Why
`MiniMax-M3` is the latest model, with a 512K context window, up to 128K output, and image input support.

## Testing
- Verified model list and default-model logic in `src/common/engines/minimax.ts` and `src/common/utils.ts`