### PR TITLE
fix: stop idle CPU burn from hidden pre-created windows (#1883)

### DIFF
--- a/src/tauri/windows/QuickTranslatorWindow.tsx
+++ b/src/tauri/windows/QuickTranslatorWindow.tsx
@@ -54,7 +54,15 @@ export function QuickTranslatorWindow() {
             <StyletronProvider value={engine}>
                 <BaseProvider theme={theme}>
                     <GlobalSuspense>
-                        <QuickTranslator key={tick} fetchContext={fetchContext} onClose={hide} onHide={hide} />
+                        {/* This window is pre-created (hidden) at app startup; don't
+                            mount QuickTranslator — which immediately runs the context
+                            picker (AX reads, history query, model call) — until the
+                            panel is actually shown for the first time (#1883). Rust
+                            emits `quick-translator-shown` on every show, so tick > 0
+                            exactly means "has been shown at least once". */}
+                        {tick > 0 && (
+                            <QuickTranslator key={tick} fetchContext={fetchContext} onClose={hide} onHide={hide} />
+                        )}
                     </GlobalSuspense>
                 </BaseProvider>
             </StyletronProvider>

--- a/src/tauri/windows/WritingIndicatorWindow.tsx
+++ b/src/tauri/windows/WritingIndicatorWindow.tsx
@@ -162,10 +162,13 @@ const PulsingDots = () => (
 export function WritingIndicatorWindow() {
     const [lang, setLang] = useState<string>('')
     const [done, setDone] = useState(false)
-    // Render content immediately on mount. The native window itself is hidden
-    // by default and Rust only `window.show()`s during an active writing
-    // trigger, so the panel only reaches the screen during real work.
-    const [visible, setVisible] = useState(true)
+    // Start hidden: this window is pre-created at app startup and lives
+    // forever, so the infinite pen/dots animations must NOT run until a
+    // writing trigger actually shows the panel. Hidden WebView2 windows on
+    // Windows keep compositing CSS animations at full frame rate, which
+    // burned CPU from launch (#1883). The `writing-indicator-start` event
+    // (or the pending-lang recovery poll below) flips this on.
+    const [visible, setVisible] = useState(false)
     const fadeTimer = useRef<number | null>(null)
 
     useEffect(() => {
@@ -241,9 +244,14 @@ export function WritingIndicatorWindow() {
     return (
         <div style={PANEL_STYLE}>
             <div style={row}>
-                <span style={ICON_WRAPPER}>{done ? <CheckIcon /> : <PenIcon />}</span>
+                {/* Mount the infinitely-animating pen/dots only while the
+                    panel is logically visible — otherwise they keep the
+                    hidden WebView2 window compositing forever (#1883). The
+                    check icon's animation is finite, so it may stay mounted
+                    through the fade-out. */}
+                <span style={ICON_WRAPPER}>{done ? <CheckIcon /> : visible ? <PenIcon /> : null}</span>
                 <span style={LABEL_STYLE}>{done ? 'Done' : languageLabel(lang)}</span>
-                {!done && <PulsingDots />}
+                {!done && visible && <PulsingDots />}
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary

Fixes #1883 — excessive idle CPU usage in WebView2 on Windows since v0.6.16 (also reported on 0.6.17/0.6.18), even with no user interaction and while minimized to the system tray.

## Root cause

v0.6.16 started pre-creating two hidden, transparent webview windows at app startup (`main.rs` setup): the writing-indicator HUD and the Quick Translator panel. Unlike macOS (which throttles occluded WKWebViews), hidden WebView2 windows keep compositing at full frame rate:

1. **Writing HUD** (`WritingIndicatorWindow.tsx`) mounted with `visible = true` and ran infinite CSS animations (`wi-pen-wobble 1.8s infinite` + 3× `wi-dot-pulse 1.3s infinite`) from launch, forever — exactly matching the reports: CPU burn starts immediately at startup, persists in the tray.
2. **Quick Translator** mounted at startup and immediately ran its context picker (AX reads, history query, potential model call) in a window nobody had opened.

## Fix

- `WritingIndicatorWindow.tsx`: initial `visible` is now `false`; the infinitely-animating pen/dots only mount while the panel is logically visible (driven by the existing `writing-indicator-start`/`finish` events and the pending-lang recovery poll). The finite check-pop animation and fade-out sequencing are unchanged.
- `QuickTranslatorWindow.tsx`: `QuickTranslator` no longer mounts until the first `quick-translator-shown` event (emitted by Rust on every show; the listener is wired at startup, so no race). The existing `key={tick}` remount-per-show behavior is unchanged.

## Test plan

- `tsc --noEmit` and ESLint pass.
- macOS: writing flow still shows the HUD with animations and fades out on finish; Quick Translator opens and runs the picker on first show.
- Windows validation: after launch with no interaction, the app's WebView2 processes should sit at ~0% CPU in Task Manager (previously up to ~45%).