### PR TITLE
fix: suspend WebView2 renderers for hidden panels on Windows (#1886)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -449,17 +449,23 @@ fn main() {
             app_handle.plugin(tauri_plugin_updater::Builder::new().build())?;
             // create thumb window
             let _ = windows::get_thumb_window(0, 0);
-            // Pre-create the Quick Translator panel on the main thread.
-            // Window creation + raw cocoa msg_send calls (setLevel:, etc.) must
-            // run on the AppKit main thread; if we let it happen lazily inside
-            // an async Tauri command (which runs on a tokio worker thread),
-            // macOS aborts the process with
+            // Pre-create the Quick Translator and writing-indicator panels —
+            // but ONLY on macOS. There the raw cocoa msg_send calls (setLevel:,
+            // etc.) must run on the AppKit main thread; if we let creation
+            // happen lazily inside an async Tauri command (which runs on a
+            // tokio worker thread), macOS aborts the process with
             // "Must only be used from the main thread" / EXC_BREAKPOINT.
-            let _ = windows::get_quick_translator_window();
-            // Same main-thread-only reasoning as the Quick Translator: pre-create
-            // the writing-indicator panel here so its NSWindow + setLevel calls
-            // happen on the AppKit main thread instead of inside a tokio worker.
-            let _ = windows::get_writing_indicator_window();
+            //
+            // On Windows neither constraint applies, and pre-creating these
+            // hidden transparent WebView2 windows kept their renderers
+            // compositing at full frame rate from launch, burning CPU while
+            // the app idled in the tray (#1883, #1886). They are created
+            // lazily on first use instead.
+            #[cfg(target_os = "macos")]
+            {
+                let _ = windows::get_quick_translator_window();
+                let _ = windows::get_writing_indicator_window();
+            }
             if silently {
                 // create translator window
                 let _ = get_translator_window(false, false, false);

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -331,6 +331,24 @@ pub fn post_process_window<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) 
     }
 }
 
+/// Tauri/wry never propagate native window visibility to the WebView2
+/// controller on Windows: a window created with `.visible(false)` — or hidden
+/// later via `window.hide()` — keeps `ICoreWebView2Controller.IsVisible ==
+/// TRUE`, so its renderer keeps compositing frames. For the transparent,
+/// always-alive panel windows (Quick Translator, writing indicator) that
+/// meant constant WebView2 CPU usage while the app sat idle in the tray
+/// (#1883, #1886). Explicitly sync the controller whenever those panels are
+/// created hidden, shown, or hidden again.
+#[cfg(target_os = "windows")]
+pub fn set_webview_visibility(window: &tauri::WebviewWindow, visible: bool) {
+    let _ = window.with_webview(move |webview| unsafe {
+        let _ = webview.controller().SetIsVisible(visible);
+    });
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn set_webview_visibility(_window: &tauri::WebviewWindow, _visible: bool) {}
+
 pub fn build_window<'a, R: tauri::Runtime, M: tauri::Manager<R>>(
     builder: tauri::WebviewWindowBuilder<'a, R, M>,
 ) -> tauri::WebviewWindow<R> {
@@ -960,6 +978,8 @@ pub fn get_quick_translator_window() -> tauri::WebviewWindow {
     let window = builder.build().unwrap();
     post_process_window(&window);
     apply_quick_translator_panel_traits(&window);
+    // Created hidden — suspend the WebView2 renderer until first show.
+    set_webview_visibility(&window, false);
 
     #[cfg(target_os = "macos")]
     {
@@ -1005,6 +1025,7 @@ fn position_quick_translator_window(window: &tauri::WebviewWindow) {
 pub fn show_quick_translator_window() -> tauri::WebviewWindow {
     let window = get_quick_translator_window();
     position_quick_translator_window(&window);
+    set_webview_visibility(&window, true);
     let _ = window.show();
     let _ = window.set_always_on_top(true);
     if let Err(e) = APP_HANDLE
@@ -1031,6 +1052,7 @@ pub async fn hide_quick_translator_window() {
         if let Some(window) = handle.get_webview_window(QUICK_TRANSLATOR_WIN_NAME) {
             let _ = window.set_always_on_top(false);
             let _ = window.hide();
+            set_webview_visibility(&window, false);
         }
     }
 }
@@ -1114,6 +1136,8 @@ pub fn get_writing_indicator_window() -> tauri::WebviewWindow {
     let window = builder.build().unwrap();
     post_process_window(&window);
     apply_writing_indicator_panel_traits(&window);
+    // Created hidden — suspend the WebView2 renderer until first show.
+    set_webview_visibility(&window, false);
 
     // Native macOS HUD vibrancy material. With the NSWindow background set to
     // clearColor (above) the effect material is what the user actually sees
@@ -1223,6 +1247,7 @@ pub async fn show_writing_indicator(target_language: String) {
     // Mirror state for the React mount-time poll.
     *WRITING_INDICATOR_PENDING_LANG.lock() = Some(target_language.clone());
 
+    set_webview_visibility(&window, true);
     let _ = window.show();
     let _ = window.set_always_on_top(true);
     if let Some(handle) = APP_HANDLE.get() {
@@ -1269,6 +1294,7 @@ pub async fn hide_writing_indicator() {
                     debug_println!("[indicator] window.hide() failed: {:?}", e);
                 }
             }
+            set_webview_visibility(&window, false);
         }
     }
 }

--- a/src-tauri/src/writing.rs
+++ b/src-tauri/src/writing.rs
@@ -314,6 +314,7 @@ pub fn finish_writing() {
             {
                 let _ = window.set_always_on_top(false);
                 let _ = window.hide();
+                crate::windows::set_webview_visibility(&window, false);
                 debug_println!("[writing] indicator window hidden by Rust authoritative path");
             }
         });

--- a/src/tauri/windows/QuickTranslatorWindow.tsx
+++ b/src/tauri/windows/QuickTranslatorWindow.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { Client as Styletron } from 'styletron-engine-atomic'
 import { Provider as StyletronProvider } from 'styletron-react'
 import { BaseProvider } from 'baseui-sd'
@@ -39,12 +40,26 @@ export function QuickTranslatorWindow() {
 
     useEffect(() => {
         let unlisten: UnlistenFn | undefined
+        let cancelled = false
         ;(async () => {
             unlisten = await listen('quick-translator-shown', () => {
                 setTick((n) => n + 1)
             })
+            // Race recovery: on Windows this window is created lazily on the
+            // first hotkey press, so the first `quick-translator-shown` emit
+            // happens before this listener is wired up. If the window is
+            // already visible at mount, treat that as the missed first show.
+            try {
+                const visible = await WebviewWindow.getCurrent().isVisible()
+                if (!cancelled && visible) {
+                    setTick((n) => (n === 0 ? 1 : n))
+                }
+            } catch {
+                // ignore — worst case the panel stays empty until the next show
+            }
         })()
         return () => {
+            cancelled = true
             unlisten?.()
         }
     }, [])


### PR DESCRIPTION
## Summary

Follow-up to #1885. Fixes #1886 — idle CPU on Windows stayed at ~38% in v0.6.19 even after the previous fix.

#1885 only stopped the **React-side CSS animations**. That was necessary but not sufficient: the WebView2 renderer keeps compositing regardless of whether any CSS is animating.

## Root cause (confirmed at the Tauri/wry source level)

The two panel windows (Quick Translator + writing indicator) are pre-created hidden at startup and live forever. On Windows:

- `WebviewWindow::hide()` → `dispatcher.hide()` → `WindowMessage::Hide` → `window.set_visible(false)` — this only hides the **tao OS window**.
- It never sends `WebviewMessage::Hide` (the message that calls `webview.set_visible` → `controller.SetIsVisible`).

So the `ICoreWebView2Controller.IsVisible` flag stays `TRUE`, and the WebView2 renderer keeps compositing frames at full rate for a window that is invisible on screen — burning CPU the whole time the app sits idle in the tray.

## Fix

**1. Sync the WebView2 controller explicitly** — new `windows::set_webview_visibility()` reaches the controller via `with_webview()` and calls `SetIsVisible()` (the exact call wry uses internally, but which `window.hide()`/`.show()` never reach). Wired into every create / show / hide path of both panels, plus the Rust-authoritative delayed hide in `writing.rs`.

**2. Don't pre-create the panels at startup on Windows** — the macOS main-thread constraint that motivated eager pre-creation doesn't apply on Windows, and creating hidden WebView2 windows up front is what put their renderers into the always-compositing state from launch. They're now created lazily on first use. `QuickTranslatorWindow` gains an `isVisible()` mount check so the first `quick-translator-shown` event that lazy creation would otherwise miss is recovered.

Both changes are `#[cfg(target_os = "windows")]` / macOS-gated, so macOS behavior is unchanged.

## Verification

- ✅ Cross-compiled for `x86_64-pc-windows-msvc` (via cargo-xwin) — confirms the WebView2 FFI (`controller().SetIsVisible(...)`) is API-correct, which the macOS `cargo check` does not exercise.
- ✅ macOS `cargo check` passes.
- ✅ Frontend `tsc --noEmit` passes.
- ⏳ **Runtime CPU drop needs confirmation on a real Windows machine** — I don't have one. CI builds a Windows installer on this PR; would appreciate the reporters on #1886 (@bisslot et al.) testing it against Task Manager idle CPU before release.