### PR TITLE
docs: translate TeamoRouter sponsor blurb to Chinese in README-CN

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -49,7 +49,7 @@
 </p>
 
 <p>
-  TeamoRouter is an agentic LLM unified gateway for enterprises and professionals — no subscription required. Run popular agents like Claude Code and Codex across hundreds of first-party and vetted third-party providers (OpenAI, Claude, Gemini, AWS Bedrock), at discounts of up to 90% off. Unlike typical relays that rotate account pools — crippling prompt cache and quietly swapping in weaker models — TeamoRouter enforces 100% agent-protocol compatibility, cache-rate checks, and full token-level source traceability, delivering near-100% cache hit rates, millisecond-aligned TTFT, and 99.5%+ SLA. It already processes tens of billions of tokens a day for AskManyAI's millions of users. <a href="https://teamorouter.com/?utm_source=nextai_translator&amp;utm_medium=referral&amp;utm_campaign=ai_directory" target="_blank">Click here to start using TeamoRouter</a>
+  TeamoRouter 是一款面向企业与专业用户的 Agentic LLM 统一网关，无需订阅。你可以在数百家一方及经过甄选的三方供应商（OpenAI、Claude、Gemini、AWS Bedrock）上运行 Claude Code、Codex 等热门 Agent，最高可省 90%。不同于那些靠轮换账号池、进而拖垮 prompt 缓存并悄悄替换为更弱模型的普通中转，TeamoRouter 强制保证 100% 的 Agent 协议兼容、缓存命中率校验以及完整的 token 级来源可追溯，从而实现接近 100% 的缓存命中率、毫秒级对齐的 TTFT 以及 99.5%+ 的 SLA。目前它已在 AskManyAI 为数百万用户每天处理数百亿 tokens。<a href="https://teamorouter.com/?utm_source=nextai_translator&amp;utm_medium=referral&amp;utm_campaign=ai_directory" target="_blank">点击这里开始使用 TeamoRouter</a>
 </p>
 
 # 为啥要造这个轮子？


### PR DESCRIPTION
Follow-up to #1892. Translates the TeamoRouter sponsor description in `README-CN.md` into Chinese for Chinese-speaking readers.

- All technical claims/numbers preserved (up to 90% off, ~100% cache hit, 99.5%+ SLA, tens of billions of tokens/day).
- Referral link and UTM parameters unchanged; link anchor localized to 点击这里开始使用 TeamoRouter.
- English `README.md` is left as-is (sponsor's original copy).