### PR TITLE
fix: use universal fetch for TeamoRouter model listing

### DIFF
--- a/src/common/engines/teamorouter.ts
+++ b/src/common/engines/teamorouter.ts
@@ -1,4 +1,5 @@
 import { urlJoin } from 'url-join-ts'
+import { getUniversalFetch } from '../universal-fetch'
 import { getSettings } from '../utils'
 import { AbstractOpenAI } from './abstract-openai'
 import { IModel } from './interfaces'
@@ -14,7 +15,8 @@ export class TeamoRouter extends AbstractOpenAI {
             return []
         }
         const url = urlJoin(apiURL, '/v1/models')
-        const response = await fetch(url, {
+        const fetcher = getUniversalFetch()
+        const response = await fetcher(url, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
Follow-up to #1896/#1897. The TeamoRouter **API Model** selector showed "Load failed" in the desktop app.

**Cause:** `listModels()` used the global `fetch`. In the Tauri (WebKit) webview that's a cross-origin request, and `api.teamorouter.com` sends no `Access-Control-Allow-Origin` header, so the webview blocks it → "Load failed". (The endpoint/auth are correct — verified `GET /v1/models` returns 401 asking for `Authorization: Bearer`, which the engine sends.)

**Fix:** use `getUniversalFetch()`, which routes through Tauri's native HTTP client and isn't subject to CORS — matching the Groq and Cerebras engines. Translation already worked (it uses the native fetch path); this only affected model listing.

tsc ✅ · eslint ✅