### PR TITLE
fix: show quit action in Linux tray menu

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -57,6 +57,10 @@ pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
     if ALWAYS_ON_TOP.load(Ordering::Acquire) {
         pin_i.set_text("Unpin").unwrap();
     }
+    // Tauri predefined quit items are unsupported on Linux.
+    #[cfg(target_os = "linux")]
+    let quit_i = MenuItem::with_id(app, "quit", "Quit", true, None::<String>)?;
+    #[cfg(not(target_os = "linux"))]
     let quit_i = PredefinedMenuItem::quit(app, Some("Quit"))?;
     let separator_i = PredefinedMenuItem::separator(app)?;
     let menu = Menu::with_items(


### PR DESCRIPTION
## Summary

- use a regular `MenuItem` with the existing `quit` id on Linux
- keep Tauri's predefined quit item on non-Linux platforms

## Why

Tauri's predefined quit menu item is unsupported on Linux. As a result, the StatusNotifier/AppIndicator tray menu omitted the Quit action even though the existing event handler already handled the `quit` id.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm build-tauri-renderer`
- `pnpm test` (10 tests passed)
- `pnpm lint`
- `pnpm exec tauri build --bundles deb --config '{"bundle":{"createUpdaterArtifacts":false}}'`
- Ubuntu 24.04 / KDE Plasma X11: confirmed the registered StatusNotifier menu contains `Quit`; activating it exited the tested application process
