### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -1478,6 +1478,7 @@ export function ProviderSelector({ value, onChange, hasPromotion }: IProviderSel
               { label: 'OpenAI', id: 'OpenAI' },
               { label: 'TeamoRouter', id: 'TeamoRouter' },
               { label: 'OpenRouter', id: 'OpenRouter' },
+              { label: 'LiteLLM', id: 'LiteLLM' },
               { label: 'Claude', id: 'Claude' },
               { label: `Kimi (${t('Free')})`, id: 'Kimi' },
               { label: `${t('ChatGLM')} (${t('Free')})`, id: 'ChatGLM' },
@@ -1499,6 +1500,7 @@ export function ProviderSelector({ value, onChange, hasPromotion }: IProviderSel
               { label: 'OpenAI', id: 'OpenAI' },
               { label: 'TeamoRouter', id: 'TeamoRouter' },
               { label: 'OpenRouter', id: 'OpenRouter' },
+              { label: 'LiteLLM', id: 'LiteLLM' },
               { label: 'Claude', id: 'Claude' },
               { label: `Kimi (${t('Free')})`, id: 'Kimi' },
               { label: `${t('ChatGLM')} (${t('Free')})`, id: 'ChatGLM' },
@@ -3412,6 +3414,40 @@ export function InnerSettings({
                                     provider='OpenRouter'
                                     currentProvider={values.provider}
                                     apiKey={values.openRouterAPIKey}
+                                    onBlur={onBlur}
+                                />
+                            </FormItem>
+                        </div>
+                        <div
+                            style={{
+                                display: values.provider === 'LiteLLM' ? 'block' : 'none',
+                            }}
+                        >
+                            <FormItem
+                                required={values.provider === 'LiteLLM'}
+                                name='liteLLMAPIURL'
+                                label={t('API URL')}
+                                caption='The base URL of your LiteLLM proxy server, e.g. http://localhost:4000'
+                            >
+                                <Input autoFocus size='compact' onBlur={onBlur} />
+                            </FormItem>
+                            <FormItem
+                                required={values.provider === 'LiteLLM'}
+                                name='liteLLMAPIKey'
+                                label='LiteLLM API Key'
+                                caption='Your LiteLLM proxy virtual key or master key. Leave blank if your proxy has no authentication.'
+                            >
+                                <Input type='password' size='compact' onBlur={onBlur} />
+                            </FormItem>
+                            <FormItem
+                                name='liteLLMAPIModel'
+                                label={t('API Model')}
+                                required={values.provider === 'LiteLLM'}
+                            >
+                                <APIModelSelector
+                                    provider='LiteLLM'
+                                    currentProvider={values.provider}
+                                    apiKey={values.liteLLMAPIKey}
                                     onBlur={onBlur}
                                 />
                             </FormItem>

--- a/src/common/components/icons/LiteLLMIcon.tsx
+++ b/src/common/components/icons/LiteLLMIcon.tsx
@@ -1,0 +1,22 @@
+import { IconBaseProps } from 'react-icons'
+
+// LiteLLM's brand mark is the bullet-train emoji, so we render it directly and
+// scale it to the requested icon size instead of shipping a separate asset.
+export function LiteLLMIcon(props: IconBaseProps) {
+    const size = props.size ?? '1em'
+    return (
+        <span
+            role='img'
+            aria-label='LiteLLM'
+            style={{
+                fontSize: size,
+                lineHeight: 1,
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+            }}
+        >
+            {'\u{1F685}'}
+        </span>
+    )
+}

--- a/src/common/engines/index.ts
+++ b/src/common/engines/index.ts
@@ -31,6 +31,8 @@ import { TeamoRouterIcon } from '@/common/components/icons/TeamoRouterIcon'
 import { TeamoRouter } from './teamorouter'
 import { OpenRouterIcon } from '@/common/components/icons/OpenRouterIcon'
 import { OpenRouter } from './openrouter'
+import { LiteLLMIcon } from '@/common/components/icons/LiteLLMIcon'
+import { LiteLLM } from './litellm'
 
 export type Provider =
     | 'OpenAI'
@@ -49,6 +51,7 @@ export type Provider =
     | 'Cerebras'
     | 'TeamoRouter'
     | 'OpenRouter'
+    | 'LiteLLM'
 
 export const engineIcons: Record<Provider, IconType> = {
     OpenAI: RiOpenaiFill,
@@ -67,6 +70,7 @@ export const engineIcons: Record<Provider, IconType> = {
     Cerebras: CerebrasIcon,
     TeamoRouter: TeamoRouterIcon,
     OpenRouter: OpenRouterIcon,
+    LiteLLM: LiteLLMIcon,
 }
 
 export const providerToEngine: Record<Provider, { new (): IEngine }> = {
@@ -86,6 +90,7 @@ export const providerToEngine: Record<Provider, { new (): IEngine }> = {
     Cerebras: Cerebras,
     TeamoRouter: TeamoRouter,
     OpenRouter: OpenRouter,
+    LiteLLM: LiteLLM,
 }
 
 export function getEngine(provider: Provider): IEngine {

--- a/src/common/engines/litellm.spec.ts
+++ b/src/common/engines/litellm.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LiteLLM } from './litellm'
+import { getSettings } from '../utils'
+import { getUniversalFetch } from '../universal-fetch'
+
+vi.mock('../utils', () => {
+    return {
+        getSettings: vi.fn(),
+    }
+})
+
+vi.mock('../universal-fetch', () => {
+    return {
+        getUniversalFetch: vi.fn(),
+    }
+})
+
+const mockedGetSettings = vi.mocked(getSettings)
+const mockedGetUniversalFetch = vi.mocked(getUniversalFetch)
+
+function mockSettings(overrides: Record<string, unknown> = {}) {
+    mockedGetSettings.mockResolvedValue({
+        liteLLMAPIURL: 'http://localhost:4000',
+        liteLLMAPIKey: 'sk-test-key',
+        liteLLMAPIModel: 'gpt-4o-mini',
+        ...overrides,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+}
+
+describe('LiteLLM', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('resolves endpoint, key and model from settings', async () => {
+        mockSettings()
+        const engine = new LiteLLM()
+        expect(await engine.getAPIURL()).toBe('http://localhost:4000')
+        expect(await engine.getAPIKey()).toBe('sk-test-key')
+        expect(await engine.getAPIModel()).toBe('gpt-4o-mini')
+        expect(await engine.getAPIURLPath()).toBe('/v1/chat/completions')
+    })
+
+    it('lists models from the proxy /v1/models endpoint with the bearer key', async () => {
+        mockSettings()
+        const fetcher = vi.fn().mockResolvedValue({
+            status: 200,
+            json: async () => ({
+                data: [{ id: 'gpt-4o-mini' }, { id: 'anthropic/claude-sonnet-4-5' }],
+            }),
+        })
+        mockedGetUniversalFetch.mockReturnValue(fetcher)
+
+        const engine = new LiteLLM()
+        const models = await engine.listModels(undefined)
+
+        expect(fetcher).toHaveBeenCalledWith(
+            'http://localhost:4000/v1/models',
+            expect.objectContaining({
+                method: 'GET',
+                headers: expect.objectContaining({ Authorization: 'Bearer sk-test-key' }),
+            })
+        )
+        expect(models).toEqual([
+            { id: 'gpt-4o-mini', name: 'gpt-4o-mini' },
+            { id: 'anthropic/claude-sonnet-4-5', name: 'anthropic/claude-sonnet-4-5' },
+        ])
+    })
+
+    it('omits the Authorization header when no key is configured', async () => {
+        mockSettings({ liteLLMAPIKey: '' })
+        const fetcher = vi.fn().mockResolvedValue({
+            status: 200,
+            json: async () => ({ data: [] }),
+        })
+        mockedGetUniversalFetch.mockReturnValue(fetcher)
+
+        const engine = new LiteLLM()
+        await engine.listModels(undefined)
+
+        const headers = fetcher.mock.calls[0][1].headers
+        expect(headers.Authorization).toBeUndefined()
+    })
+
+    it('returns an empty list when no base URL is set', async () => {
+        mockSettings({ liteLLMAPIURL: '' })
+        const engine = new LiteLLM()
+        expect(await engine.listModels(undefined)).toEqual([])
+    })
+
+    it('throws a clear error on an invalid key', async () => {
+        mockSettings()
+        const fetcher = vi.fn().mockResolvedValue({ status: 401, statusText: 'Unauthorized' })
+        mockedGetUniversalFetch.mockReturnValue(fetcher)
+
+        const engine = new LiteLLM()
+        await expect(engine.listModels(undefined)).rejects.toThrow('Invalid API key')
+    })
+})

--- a/src/common/engines/litellm.ts
+++ b/src/common/engines/litellm.ts
@@ -1,0 +1,69 @@
+import { urlJoin } from 'url-join-ts'
+import { getUniversalFetch } from '../universal-fetch'
+import { getSettings } from '../utils'
+import { AbstractOpenAI } from './abstract-openai'
+import { IModel } from './interfaces'
+
+// LiteLLM proxy exposes an OpenAI-compatible API, so we reuse AbstractOpenAI for
+// chat completions and only override the endpoint resolution and model listing.
+// Unlike a hosted gateway, the base URL points at the user's own proxy, so it is
+// read from settings instead of being hardcoded.
+export class LiteLLM extends AbstractOpenAI {
+    async listModels(apiKey_: string | undefined): Promise<IModel[]> {
+        let apiKey = apiKey_
+        if (!apiKey) {
+            apiKey = await this.getAPIKey()
+        }
+        const apiURL = await this.getAPIURL()
+        if (!apiURL) {
+            return []
+        }
+        const url = urlJoin(apiURL, '/v1/models')
+        const fetcher = getUniversalFetch()
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        }
+        // A LiteLLM proxy usually requires a virtual/master key, but some run
+        // without auth, so only send the header when a key is configured.
+        if (apiKey) {
+            headers['Authorization'] = `Bearer ${apiKey}`
+        }
+        const response = await fetcher(url, {
+            method: 'GET',
+            headers,
+        })
+        if (response.status !== 200) {
+            if (response.status === 401 || response.status === 403) {
+                throw new Error('Invalid API key')
+            }
+            if (response.status === 404) {
+                throw new Error('Invalid API URL')
+            }
+            throw new Error(`Failed to list models: ${response.statusText}`)
+        }
+        const json = await response.json()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return json.data.map((model: any) => {
+            return {
+                id: model.id,
+                name: model.id,
+            }
+        })
+    }
+
+    async getAPIModel(): Promise<string> {
+        const settings = await getSettings()
+        return settings.liteLLMAPIModel
+    }
+    async getAPIKey(): Promise<string> {
+        const settings = await getSettings()
+        return settings.liteLLMAPIKey
+    }
+    async getAPIURL(): Promise<string> {
+        const settings = await getSettings()
+        return settings.liteLLMAPIURL
+    }
+    async getAPIURLPath(): Promise<string> {
+        return '/v1/chat/completions'
+    }
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -146,6 +146,9 @@ export interface ISettings {
     teamoRouterAPIModel: string
     openRouterAPIKey: string
     openRouterAPIModel: string
+    liteLLMAPIURL: string
+    liteLLMAPIKey: string
+    liteLLMAPIModel: string
     fontSize: number
     uiFontSize: number
     iconSize: number

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -117,6 +117,9 @@ const settingKeys: Record<keyof ISettings, number> = {
     teamoRouterAPIModel: 1,
     openRouterAPIKey: 1,
     openRouterAPIModel: 1,
+    liteLLMAPIURL: 1,
+    liteLLMAPIKey: 1,
+    liteLLMAPIModel: 1,
     fontSize: 1,
     uiFontSize: 1,
     iconSize: 1,
@@ -240,6 +243,9 @@ export async function getSettings(): Promise<ISettings> {
     }
     if (!settings.groqAPIURLPath) {
         settings.groqAPIURLPath = '/openai/v1/chat/completions'
+    }
+    if (!settings.liteLLMAPIURL) {
+        settings.liteLLMAPIURL = 'http://localhost:4000'
     }
     if (!settings.claudeAPIURL) {
         settings.claudeAPIURL = 'https://api.anthropic.com'
@@ -609,6 +615,8 @@ export function getAPIKeyForProvider(provider: string, settings: ISettings): str
             return settings.teamoRouterAPIKey
         case 'OpenRouter':
             return settings.openRouterAPIKey
+        case 'LiteLLM':
+            return settings.liteLLMAPIKey
         case 'Moonshot':
             return settings.moonshotAPIKey
         case 'MiniMax':


### PR DESCRIPTION
## Summary

Adds **LiteLLM** as a first-class provider, so users can point NextAI Translator at their own [LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy) and reach 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, DeepSeek, Mistral, local models, and more) through one OpenAI-compatible endpoint, with per-key spend tracking, fallbacks, and rate limits handled by the proxy.

**No new npm dependency is added.** 


## Changes

- `src/common/engines/litellm.ts`: new `LiteLLM` engine extending `AbstractOpenAI`; user-configurable `getAPIURL()`, `/v1/models` listing, `/v1/chat/completions` path.
- `src/common/components/icons/LiteLLMIcon.tsx`: provider icon (LiteLLM's bullet-train mark).
- `src/common/engines/index.ts`: registered in the `Provider` union, `engineIcons`, and `providerToEngine`.
- `src/common/types.ts`: added `liteLLMAPIURL` / `liteLLMAPIKey` / `liteLLMAPIModel` to `ISettings`.
- `src/common/utils.ts`: settings keys, default proxy URL (`http://localhost:4000`), and provider case in `getAPIKey`.
- `src/common/components/Settings.tsx`: provider dropdown entries (desktop + browser) and the settings form (API URL, API Key, model selector).
- `src/common/engines/litellm.spec.ts`: unit tests for settings resolution and model listing.

## Tests

**1. Unit tests** (`pnpm exec vitest run`): full suite green, including the new engine tests.

```
[PASS] common/engines/litellm.spec.ts (5 tests)
[PASS] common/engines/abstract-openai.spec.ts (15 tests)
...
Test Files  9 passed (9)
     Tests  60 passed (60)
```

**2. Lint / format / types**

```
eslint "src/**/*.{ts,tsx}"        clean
prettier --check <changed files>  All matched files use Prettier code style!
tsc --noEmit                      clean
```

**3. Live end-to-end against a real LiteLLM proxy**

Ran the actual engine code (`listModels` + streaming `sendMessage`) against a running LiteLLM proxy backed by Azure OpenAI. Only the browser transport shim was swapped for Node `fetch`; all parsing/streaming logic is the shipped code path.

```
LIVE listModels count: 10  sample: [ 'azure/gpt-4.1', 'azure/gpt-4o', 'azure/gpt-4.1-mini' ]
LIVE stream text: "4"  finish_reason: stop
```

This exercises the full chain: engine, then `/v1/models` discovery and `/v1/chat/completions` SSE streaming, then the proxy, then the upstream provider, then the parsed response.

## Risk / compatibility

- Additive only. No existing provider or behavior is changed.
- No new dependency; base install size unaffected.

## Example usage

**1. Configure a LiteLLM proxy** (`config.yaml`), exposing any mix of providers behind one OpenAI-compatible endpoint:

```yaml
model_list:
  - model_name: gpt-4o
    litellm_params:
      model: azure/gpt-4o
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
  - model_name: claude-sonnet
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
```

```bash
litellm --config config.yaml
```

**2. In NextAI Translator Settings**: choose provider **LiteLLM**, the proxy URL to wherever your LiteLLM deployment lives, a local proxy (`http://localhost:4000`) or a hosted/team one (`https://litellm.your-company.com`), plus a virtual/master key if the proxy enforces auth. The model list auto-populates from `/v1/models`; pick a model and translate.

```ts
import { getEngine } from '@/common/engines'

const engine = getEngine('LiteLLM')

// Auto-discovered from the proxy's /v1/models endpoint
const models = await engine.listModels(undefined)

// Streaming translation through the proxy
await engine.sendMessage({
    rolePrompt: 'You are a translator.',
    commandPrompt: "Translate 'hello' to French.",
    onMessage: async ({ content }) => process.stdout.write(content),
    onError: (err) => console.error(err),
    onFinished: () => {},
    signal: new AbortController().signal,
})
```
