### PR TITLE
i18n: complete missing Korean translations for the dictionary feature

### DIFF
--- a/src/common/i18n/locales/ko/translation.json
+++ b/src/common/i18n/locales/ko/translation.json
@@ -239,5 +239,10 @@
     "Download progress for {{voice}}": "{{voice}} 다운로드 진행률",
     "Verifying and extracting…": "검증 및 압축 해제 중…",
     "{{voice}} is ready": "{{voice}} 준비 완료",
-    "Failed to download {{voice}}": "{{voice}} 다운로드 실패"
+    "Failed to download {{voice}}": "{{voice}} 다운로드 실패",
+    "Definition of {{word}}": "{{word}}의 정의",
+    "No concise definition found": "간결한 정의를 찾을 수 없습니다",
+    "Open full definition": "전체 정의 열기",
+    "Preview unavailable": "미리보기를 사용할 수 없습니다",
+    "Source: Wiktionary": "출처: 위키낱말사전"
 }


### PR DESCRIPTION
## Summary
#1895 added the Korean (`ko`) translation, but the dictionary / hover-word-definition feature (added in #1899) introduced 5 new UI strings that were never translated into Korean.

## Changes
Add the 5 missing Korean strings so Korean users no longer see English fallback for the dictionary feature:
- `Definition of {{word}}` → `{{word}}의 정의`
- `No concise definition found` → `간결한 정의를 찾을 수 없습니다`
- `Open full definition` → `전체 정의 열기`
- `Preview unavailable` → `미리보기를 사용할 수 없습니다`
- `Source: Wiktionary` → `출처: 위키낱말사전`

This is a pure `translation.json` change — no application logic is touched.

## Test plan
- JSON-only change; lint / type-check are unaffected.
- Switch the UI language to Korean; the dictionary / definition cards and related history strings now render in Korean instead of English.
