### PR TITLE
fix: render GFM tables in Markdown + fix Tauri Vite build on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Normalize line endings across platforms.
+# Repo stores text as LF; Git converts on checkout per rules below.
+
+# Default: treat as text, store LF in the repo, check out LF.
+* text=auto eol=lf
+
+# Windows-only scripts must stay CRLF.
+*.bat  text eol=crlf
+*.cmd  text eol=crlf
+*.ps1  text eol=crlf
+
+# Binary files: never touch line endings.
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.icns   binary
+*.woff   binary
+*.woff2  binary
+*.ttf    binary
+*.otf    binary
+*.eot    binary
+*.pdf    binary
+*.zip    binary
+*.gz     binary
+*.dll    binary
+*.exe    binary
+*.so     binary
+*.dylib  binary
+*.node   binary

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -8,4 +8,5 @@ module.exports = {
     quoteProps: 'consistent',
     bracketSpacing: true,
     printWidth: 120,
+    endOfLine: 'auto',
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "react-syntax-highlighter": "npm:@fengkx/react-syntax-highlighter@15.6.1",
     "react-use": "^17.4.2",
     "react-window": "^1.8.9",
+    "remark-gfm": "^3.0.1",
     "styletron-engine-atomic": "^1.5.0",
     "styletron-react": "^6.1.0",
     "swr": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       react-window:
         specifier: ^1.8.9
         version: 1.8.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      remark-gfm:
+        specifier: ^3.0.1
+        version: 3.0.1
       styletron-engine-atomic:
         specifier: ^1.5.0
         version: 1.5.0
@@ -1733,6 +1736,9 @@ packages:
   card-validator@6.2.0:
     resolution: {integrity: sha512-1vYv45JaE9NmixZr4dl6ykzbFKv7imI9L7MQDs235b/a7EGbG8rrEsipeHtVvscLSUbl3RX6UP5gyOe0Y2FlHA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@4.3.7:
     resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
     engines: {node: '>=4'}
@@ -2327,6 +2333,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-prettier@8.9.0:
     resolution: {integrity: sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==}
@@ -3272,6 +3282,9 @@ packages:
     resolution: {integrity: sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==}
     engines: {node: '>=18'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3308,6 +3321,9 @@ packages:
     resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
     engines: {node: '>=12'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -3319,11 +3335,38 @@ packages:
   mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
 
+  mdast-util-find-and-replace@2.2.2:
+    resolution: {integrity: sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==}
+
   mdast-util-from-markdown@1.3.0:
     resolution: {integrity: sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==}
 
+  mdast-util-gfm-autolink-literal@1.0.3:
+    resolution: {integrity: sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==}
+
+  mdast-util-gfm-footnote@1.0.2:
+    resolution: {integrity: sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==}
+
+  mdast-util-gfm-strikethrough@1.0.3:
+    resolution: {integrity: sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==}
+
+  mdast-util-gfm-table@1.0.7:
+    resolution: {integrity: sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==}
+
+  mdast-util-gfm-task-list-item@1.0.2:
+    resolution: {integrity: sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==}
+
+  mdast-util-gfm@2.0.2:
+    resolution: {integrity: sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==}
+
+  mdast-util-phrasing@3.0.1:
+    resolution: {integrity: sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==}
+
   mdast-util-to-hast@12.3.0:
     resolution: {integrity: sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==}
+
+  mdast-util-to-markdown@1.5.0:
+    resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
 
   mdast-util-to-string@3.2.0:
     resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
@@ -3343,6 +3386,27 @@ packages:
 
   micromark-core-commonmark@1.0.6:
     resolution: {integrity: sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==}
+
+  micromark-extension-gfm-autolink-literal@1.0.5:
+    resolution: {integrity: sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==}
+
+  micromark-extension-gfm-footnote@1.1.2:
+    resolution: {integrity: sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==}
+
+  micromark-extension-gfm-strikethrough@1.0.7:
+    resolution: {integrity: sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==}
+
+  micromark-extension-gfm-table@1.0.7:
+    resolution: {integrity: sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==}
+
+  micromark-extension-gfm-tagfilter@1.0.2:
+    resolution: {integrity: sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==}
+
+  micromark-extension-gfm-task-list-item@1.0.5:
+    resolution: {integrity: sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==}
+
+  micromark-extension-gfm@2.0.3:
+    resolution: {integrity: sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==}
 
   micromark-factory-destination@1.0.0:
     resolution: {integrity: sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==}
@@ -4018,6 +4082,9 @@ packages:
   regexp.prototype.flags@1.5.0:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
+
+  remark-gfm@3.0.1:
+    resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
 
   remark-parse@10.0.2:
     resolution: {integrity: sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==}
@@ -4908,6 +4975,9 @@ packages:
         optional: true
       react:
         optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -6291,6 +6361,8 @@ snapshots:
     dependencies:
       credit-card-type: 8.3.0
 
+  ccount@2.0.1: {}
+
   chai@4.3.7:
     dependencies:
       assertion-error: 1.1.0
@@ -7029,6 +7101,8 @@ snapshots:
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-prettier@8.9.0(eslint@8.46.0):
     dependencies:
@@ -8115,6 +8189,8 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -8152,6 +8228,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  markdown-table@3.0.4: {}
+
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
@@ -8164,6 +8242,13 @@ snapshots:
       '@types/mdast': 3.0.11
       '@types/unist': 2.0.10
       unist-util-visit: 4.1.2
+
+  mdast-util-find-and-replace@2.2.2:
+    dependencies:
+      '@types/mdast': 3.0.11
+      escape-string-regexp: 5.0.0
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
 
   mdast-util-from-markdown@1.3.0:
     dependencies:
@@ -8182,6 +8267,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-gfm-autolink-literal@1.0.3:
+    dependencies:
+      '@types/mdast': 3.0.11
+      ccount: 2.0.1
+      mdast-util-find-and-replace: 2.2.2
+      micromark-util-character: 1.1.0
+
+  mdast-util-gfm-footnote@1.0.2:
+    dependencies:
+      '@types/mdast': 3.0.11
+      mdast-util-to-markdown: 1.5.0
+      micromark-util-normalize-identifier: 1.0.0
+
+  mdast-util-gfm-strikethrough@1.0.3:
+    dependencies:
+      '@types/mdast': 3.0.11
+      mdast-util-to-markdown: 1.5.0
+
+  mdast-util-gfm-table@1.0.7:
+    dependencies:
+      '@types/mdast': 3.0.11
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 1.3.0
+      mdast-util-to-markdown: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@1.0.2:
+    dependencies:
+      '@types/mdast': 3.0.11
+      mdast-util-to-markdown: 1.5.0
+
+  mdast-util-gfm@2.0.2:
+    dependencies:
+      mdast-util-from-markdown: 1.3.0
+      mdast-util-gfm-autolink-literal: 1.0.3
+      mdast-util-gfm-footnote: 1.0.2
+      mdast-util-gfm-strikethrough: 1.0.3
+      mdast-util-gfm-table: 1.0.7
+      mdast-util-gfm-task-list-item: 1.0.2
+      mdast-util-to-markdown: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@3.0.1:
+    dependencies:
+      '@types/mdast': 3.0.11
+      unist-util-is: 5.2.1
+
   mdast-util-to-hast@12.3.0:
     dependencies:
       '@types/hast': 2.3.10
@@ -8192,6 +8326,17 @@ snapshots:
       unist-util-generated: 2.0.1
       unist-util-position: 4.0.4
       unist-util-visit: 4.1.2
+
+  mdast-util-to-markdown@1.5.0:
+    dependencies:
+      '@types/mdast': 3.0.11
+      '@types/unist': 2.0.10
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 3.0.1
+      mdast-util-to-string: 3.2.0
+      micromark-util-decode-string: 1.0.2
+      unist-util-visit: 4.1.2
+      zwitch: 2.0.4
 
   mdast-util-to-string@3.2.0:
     dependencies:
@@ -8223,6 +8368,64 @@ snapshots:
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
       uvu: 0.5.6
+
+  micromark-extension-gfm-autolink-literal@1.0.5:
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-sanitize-uri: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+
+  micromark-extension-gfm-footnote@1.1.2:
+    dependencies:
+      micromark-core-commonmark: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-sanitize-uri: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+
+  micromark-extension-gfm-strikethrough@1.0.7:
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-classify-character: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+
+  micromark-extension-gfm-table@1.0.7:
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+
+  micromark-extension-gfm-tagfilter@1.0.2:
+    dependencies:
+      micromark-util-types: 1.0.2
+
+  micromark-extension-gfm-task-list-item@1.0.5:
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+
+  micromark-extension-gfm@2.0.3:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 1.0.5
+      micromark-extension-gfm-footnote: 1.1.2
+      micromark-extension-gfm-strikethrough: 1.0.7
+      micromark-extension-gfm-table: 1.0.7
+      micromark-extension-gfm-tagfilter: 1.0.2
+      micromark-extension-gfm-task-list-item: 1.0.5
+      micromark-util-combine-extensions: 1.0.0
+      micromark-util-types: 1.0.2
 
   micromark-factory-destination@1.0.0:
     dependencies:
@@ -8968,6 +9171,15 @@ snapshots:
       call-bind: 1.0.2
       define-properties: 1.2.0
       functions-have-names: 1.2.3
+
+  remark-gfm@3.0.1:
+    dependencies:
+      '@types/mdast': 3.0.11
+      mdast-util-gfm: 2.0.2
+      micromark-extension-gfm: 2.0.3
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   remark-parse@10.0.2:
     dependencies:
@@ -9866,3 +10078,5 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.18
       react: 18.2.0
+
+  zwitch@2.0.4: {}

--- a/src/common/components/Markdown.spec.tsx
+++ b/src/common/components/Markdown.spec.tsx
@@ -18,6 +18,42 @@ import { HoverableText, WordHoverProvider } from './WordHoverCard'
 
 const renderHoverableText = (text: string) => <HoverableText>{text}</HoverableText>
 
+describe('GFM table rendering', () => {
+    it('renders pipe tables as HTML tables instead of plain paragraph text', () => {
+        const tableMarkdown = '| 代码 | 说明 |\n| --- | --- |\n| diff | 差值计数 |'
+        const html = renderToStaticMarkup(<Markdown>{tableMarkdown}</Markdown>)
+        expect(html).toContain('<table')
+        expect(html).toContain('<th')
+        expect(html).toContain('<td')
+        expect(html).not.toContain('|')
+    })
+})
+
+describe('GFM table styling', () => {
+    const tableMarkdown = '| 代码 | 说明 |\n| --- | --- |\n| diff | 差值计数 |'
+
+    it('draws cell borders, centers content, and bolds/darkens the header row', () => {
+        const html = renderToStaticMarkup(<Markdown>{tableMarkdown}</Markdown>)
+        expect(html).toContain('border-collapse:collapse')
+        expect(html).toMatch(/<th[^>]*font-weight:600/)
+        expect(html).toMatch(/<th[^>]*background-color:/)
+        expect(html).toMatch(/<td[^>]*text-align:center/)
+        expect(html).toMatch(/<td[^>]*vertical-align:middle/)
+        expect(html).toMatch(/<td[^>]*word-break:break-word/)
+    })
+
+    it('keeps hoverable word spans inside styled table cells', () => {
+        const html = renderToStaticMarkup(
+            <WordHoverProvider enabled onOpenDetails={() => {}}>
+                <Markdown renderText={renderHoverableText}>
+                    {'| head | col |\n| --- | --- |\n| hello world | data |'}
+                </Markdown>
+            </WordHoverProvider>
+        )
+        expect(html).toMatch(/<td[^>]*>.*role="link"/)
+    })
+})
+
 describe('hover cards + phonetics merge integration', () => {
     it('keeps hoverable word spans in markdown output when speech props are set', () => {
         const html = renderToStaticMarkup(

--- a/src/common/components/Markdown.tsx
+++ b/src/common/components/Markdown.tsx
@@ -1,7 +1,16 @@
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { CodeBlock } from './CodeBlock'
 import { useTheme } from '../hooks/useTheme'
-import { Children, createElement, HTMLAttributeAnchorTarget, HTMLAttributes, ReactNode, useMemo } from 'react'
+import {
+    Children,
+    createElement,
+    CSSProperties,
+    HTMLAttributeAnchorTarget,
+    HTMLAttributes,
+    ReactNode,
+    useMemo,
+} from 'react'
 import { LangCode } from '../lang'
 import { TTSProvider } from '../tts/types'
 import { PhoneticText } from './PhoneticText'
@@ -33,7 +42,7 @@ export function Markdown({
     ttsRate,
     ttsVolume,
 }: IMarkdownProps) {
-    const { theme } = useTheme()
+    const { theme, themeType } = useTheme()
     const renderedTextComponents = useMemo(() => {
         if (!renderText) return {}
         const renderChildren = (value: ReactNode) =>
@@ -60,10 +69,20 @@ export function Markdown({
             strong: withRenderedText('strong'),
             em: withRenderedText('em'),
             del: withRenderedText('del'),
-            td: withRenderedText('td'),
-            th: withRenderedText('th'),
         }
     }, [renderText])
+
+    const isDarkTheme = themeType === 'dark'
+    const tableCellStyle: CSSProperties = {
+        border: `1px solid ${isDarkTheme ? 'rgba(255, 255, 255, 0.28)' : 'rgba(0, 0, 0, 0.25)'}`,
+        padding: '0.4rem 0.75rem',
+        textAlign: 'center',
+        verticalAlign: 'middle',
+        wordBreak: 'break-word',
+        overflowWrap: 'break-word',
+    }
+    const renderCellText = (content: ReactNode) =>
+        renderText ? Children.map(content, (child) => (typeof child === 'string' ? renderText(child) : child)) : content
 
     const renderPhonetics = (content: ReactNode) => {
         const renderChild = (child: string): ReactNode => {
@@ -88,6 +107,7 @@ export function Markdown({
 
     return (
         <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
             components={{
                 ...renderedTextComponents,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -131,6 +151,45 @@ export function Markdown({
                     }
                     const code = (children as string[])[0]
                     return <CodeBlock code={code} language={language} />
+                },
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                table({ node, children, ...props }) {
+                    return (
+                        <table
+                            {...props}
+                            style={{
+                                borderCollapse: 'collapse',
+                                margin: '0.6rem auto',
+                                maxWidth: '100%',
+                            }}
+                        >
+                            {children}
+                        </table>
+                    )
+                },
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                th({ node, isHeader, children, ...props }) {
+                    return (
+                        <th
+                            {...props}
+                            style={{
+                                ...tableCellStyle,
+                                fontWeight: 600,
+                                backgroundColor: isDarkTheme ? 'rgba(0, 0, 0, 0.45)' : '#374151',
+                                color: isDarkTheme ? theme.colors.contentPrimary : '#ffffff',
+                            }}
+                        >
+                            {renderCellText(children)}
+                        </th>
+                    )
+                },
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                td({ node, isHeader, children, ...props }) {
+                    return (
+                        <td {...props} style={tableCellStyle}>
+                            {renderCellText(children)}
+                        </td>
+                    )
                 },
             }}
         >

--- a/vite.config.tauri.ts
+++ b/vite.config.tauri.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vite'
+import { defineConfig, normalizePath } from 'vite'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import svgr from 'vite-plugin-svgr'
 import { fileURLToPath, URL } from 'url'
+import path from 'node:path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -29,7 +30,10 @@ export default defineConfig({
         // produce sourcemaps for debug builds
         sourcemap: !!process.env.TAURI_DEBUG,
         rollupOptions: {
-            input: ['src/tauri/dummy.html', 'src/tauri/index.html'],
+            input: [
+                normalizePath(path.resolve(__dirname, 'src/tauri/dummy.html')),
+                normalizePath(path.resolve(__dirname, 'src/tauri/index.html')),
+            ],
             output: {
                 dir: 'dist/tauri',
             },


### PR DESCRIPTION
## Summary

Markdown pipe tables previously rendered as raw `|` text. This adds GFM table support and proper table styling, plus fixes a Windows-only Tauri build crash and line-ending noise.

## Changes

- **GFM tables**: add `remark-gfm` plugin so `| a | b |` markdown renders as real `<table>` (was plain paragraph text).
- **Table styling**: custom `table`/`th`/`td` renderers — collapsed borders, centered cells, bold + dark header row.
- **Hover words in cells**: table cells still run text through `renderText`, so hoverable word-definition spans keep working inside tables.
- **Windows Tauri build fix**: `vite.config.tauri.ts` now wraps HTML input paths in `normalizePath(path.resolve(...))`. Bare relative paths broke Vite's `html-inline-proxy` on Windows (map-key mismatch).
- **Line endings**: add `.gitattributes` — normalize all text to LF in the repo (cross-platform churn), with a CRLF carve-out for Windows shell scripts (`.bat`/`.cmd`/`.ps1`); binaries untouched. Also `.prettierrc.js` `endOfLine: 'auto'`.


## Tests

- New `Markdown.spec.tsx` cases: table renders as HTML (not `|` text), border/center/bold-header styling, hover spans survive inside cells.
- Manually verified in the Tauri desktop app on Windows.

## Notes

- `pnpm-lock.yaml` updated for `remark-gfm@3.0.1`.
