### PR TITLE
Harden Playwright browser install in CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: 
       - main
+  workflow_dispatch:
 
 jobs:
   e2e-test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
       - main
+      - fix/playwright-git-action-test
   pull_request:
     branches: 
       - main

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches: 
       - main
-      - fix/playwright-git-action-test
   pull_request:
     branches: 
       - main
-  workflow_dispatch:
 
 jobs:
   e2e-test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,8 +27,18 @@ jobs:
     - name: Install dependencies
       run: pnpm install --no-frozen-lockfile
 
-    - name: Install Playwright Browsers
-      run: pnpm exec playwright install chromium --with-deps
+    # Split out the apt step (the flaky part) and retry it on a bad Ubuntu mirror.
+    - name: Install Playwright system deps
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 15
+        max_attempts: 3
+        command: pnpm exec playwright install-deps chromium
+
+    # Browser binary download from Playwright CDN — separate step, own timeout.
+    - name: Install Playwright browser (chromium)
+      timeout-minutes: 5
+      run: pnpm exec playwright install chromium
 
     - name: Build Chromium extension
       run: pnpm vite build -c vite.config.chromium.ts

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,8 +37,11 @@ jobs:
 
     # Browser binary download from Playwright CDN — separate step, own timeout.
     - name: Install Playwright browser (chromium)
-      timeout-minutes: 5
-      run: pnpm exec playwright install chromium
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 15
+        max_attempts: 3
+        command: pnpm exec playwright install chromium
 
     - name: Build Chromium extension
       run: pnpm vite build -c vite.config.chromium.ts


### PR DESCRIPTION
## Why

Playwright setup in CI has been a source of intermittent failures, largely due to the flaky apt-based system dependency installation hitting bad Ubuntu mirrors.

## What changed

- **Splits browser setup into distinct steps** so the unreliable system dependency install is isolated from the CDN browser binary download.
- **Adds retry logic with dedicated timeouts** to each step, allowing transient failures (mirror hiccups, download stalls) to recover automatically instead of failing the whole run.

## Benefit

Reduces noisy, non-deterministic CI failures during Playwright setup, making test runs more reliable and less likely to require manual re-runs.