### PR TITLE
fix: settle backgroundFetch promise on error and disconnect

### DIFF
--- a/src/browser-extension/background/index.ts
+++ b/src/browser-extension/background/index.ts
@@ -69,6 +69,9 @@ async function fetchWithStream(
     const reader = response?.body?.getReader()
     if (!reader) {
         port.postMessage(responseSend)
+        // A body-less response is still a completed request: leaving the port
+        // open would keep the content script's stream and promise alive.
+        port.disconnect()
         return
     }
 

--- a/src/common/background/fetch.spec.ts
+++ b/src/common/background/fetch.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../utils', () => ({
+    isFirefox: () => false,
+}))
+
+type MessageListener = (msg: Record<string, unknown>) => void
+
+function createMockPort() {
+    const messageListeners: MessageListener[] = []
+    const disconnectListeners: (() => void)[] = []
+    return {
+        onMessage: {
+            addListener: (listener: MessageListener) => messageListeners.push(listener),
+        },
+        onDisconnect: {
+            addListener: (listener: () => void) => disconnectListeners.push(listener),
+        },
+        postMessage: vi.fn(),
+        disconnect: vi.fn(),
+        emitMessage: (msg: Record<string, unknown>) => messageListeners.forEach((listener) => listener(msg)),
+        emitDisconnect: () => disconnectListeners.forEach((listener) => listener()),
+    }
+}
+
+let port: ReturnType<typeof createMockPort>
+const connect = vi.fn(() => port)
+
+vi.mock('webextension-polyfill', () => ({
+    default: {
+        runtime: {
+            connect: (...args: unknown[]) => connect(...(args as [])),
+        },
+    },
+}))
+
+// The port is only created after an awaited dynamic import, so tests have to
+// wait for the connection before they can drive it.
+async function waitForConnect() {
+    for (let i = 0; i < 100; i++) {
+        if (port.postMessage.mock.calls.length > 0) {
+            return
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+    throw new Error('backgroundFetch never opened the port')
+}
+
+const okResponse = { ok: true, status: 200, statusText: 'OK', redirected: false, type: 'basic', url: 'https://x' }
+
+describe('backgroundFetch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        port = createMockPort()
+    })
+
+    it('rejects when the background reports an error before any data', async () => {
+        const { backgroundFetch } = await import('./fetch')
+        const promise = backgroundFetch('https://x', {})
+        await waitForConnect()
+
+        port.emitMessage({ error: { message: 'Failed to fetch', name: 'TypeError' } })
+        port.emitDisconnect()
+
+        await expect(promise).rejects.toMatchObject({ message: 'Failed to fetch', name: 'TypeError' })
+    })
+
+    it('rejects when the port disconnects without sending anything', async () => {
+        const { backgroundFetch } = await import('./fetch')
+        const promise = backgroundFetch('https://x', {})
+        await waitForConnect()
+
+        port.emitDisconnect()
+
+        await expect(promise).rejects.toThrow(/closed before any response/)
+    })
+
+    it('rejects with an AbortError when the signal is already aborted', async () => {
+        const { backgroundFetch } = await import('./fetch')
+        const controller = new AbortController()
+        controller.abort()
+
+        await expect(backgroundFetch('https://x', { signal: controller.signal })).rejects.toMatchObject({
+            name: 'AbortError',
+        })
+    })
+
+    it('rejects with an AbortError when the request is aborted mid-flight', async () => {
+        const { backgroundFetch } = await import('./fetch')
+        const controller = new AbortController()
+        const promise = backgroundFetch('https://x', { signal: controller.signal })
+        await waitForConnect()
+
+        controller.abort()
+        port.emitDisconnect()
+
+        await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    })
+
+    it('resolves with a readable response for a normal stream', async () => {
+        const { backgroundFetch } = await import('./fetch')
+        const promise = backgroundFetch('https://x', {})
+        await waitForConnect()
+
+        port.emitMessage({ ...okResponse, data: 'hello ' })
+        port.emitMessage({ ...okResponse, data: 'world' })
+
+        const response = await promise
+        expect(response.status).toBe(200)
+
+        port.emitDisconnect()
+        await expect(response.text()).resolves.toBe('hello world')
+    })
+
+    it('keeps an already resolved response resolved and surfaces a late error on the stream', async () => {
+        const { backgroundFetch } = await import('./fetch')
+        const promise = backgroundFetch('https://x', {})
+        await waitForConnect()
+
+        port.emitMessage({ ...okResponse, data: 'partial' })
+        const response = await promise
+
+        port.emitMessage({ error: { message: 'Network error', name: 'TypeError' } })
+        await expect(response.text()).rejects.toMatchObject({ message: 'Network error' })
+    })
+})

--- a/src/common/background/fetch.ts
+++ b/src/common/background/fetch.ts
@@ -42,7 +42,10 @@ export async function backgroundFetch(input: string, options: RequestInit) {
                 ? (ReadableStreamPolyfill as typeof window.ReadableStream)
                 : window.ReadableStream
             const textEncoder = new TextEncoder()
-            let resolved = false
+            // Guards the promise, not just the resolve path: every exit of this
+            // bridge (data, error, disconnect) has to settle it exactly once,
+            // otherwise the caller awaits forever.
+            let settled = false
             const browser = (await import('webextension-polyfill')).default
             const port = browser.runtime.connect({ name: BackgroundEventNames.fetch })
             const message: BackgroundFetchRequestMessage = {
@@ -58,11 +61,18 @@ export async function backgroundFetch(input: string, options: RequestInit) {
                             const e = new Error()
                             e.message = error.message
                             e.name = error.name
+                            // Erroring the stream only reaches a caller that
+                            // already has the Response; before that the
+                            // rejection is the only signal it can observe.
+                            if (!settled) {
+                                settled = true
+                                reject(e)
+                            }
                             controller.error(e)
                             return
                         }
                         controller.enqueue(textEncoder.encode(data))
-                        if (!resolved) {
+                        if (!settled) {
                             resolve({
                                 ...restResp,
                                 body: readableStream,
@@ -72,12 +82,23 @@ export async function backgroundFetch(input: string, options: RequestInit) {
                                     return JSON.parse(text)
                                 },
                             } as unknown as Response)
-                            resolved = true
+                            settled = true
                         }
                     })
 
                     port.onDisconnect.addListener(() => {
                         signal?.removeEventListener('abort', handleAbort)
+                        // The background disconnects on every terminal path,
+                        // including ones that never posted a message (an abort,
+                        // or the service worker being torn down mid-request).
+                        if (!settled) {
+                            settled = true
+                            reject(
+                                signal?.aborted
+                                    ? new DOMException('Aborted', 'AbortError')
+                                    : new Error('The connection to the background was closed before any response')
+                            )
+                        }
                         try {
                             controller.close()
                         } catch (e) {


### PR DESCRIPTION
## Problem

Requests that fail before the first byte leave the UI stuck on **"Translating…"** forever, with no error message — the only way out is to hit Stop. It reproduces easily with a wrong API base URL, an unreachable endpoint, a DNS/TLS failure, or a blocked connection.

The cause is in the content-script side of the background fetch bridge. `backgroundFetch` only ever calls `resolve()`, and only from the branch that receives a message carrying `data`. Neither failure path settles the promise:

- an `{ error }` message calls `controller.error(e)` and returns. That reaches a caller that already holds the `Response` and is reading the stream, but before `resolve()` has run there is no `Response`, so nothing observes it.
- `port.onDisconnect` only calls `controller.close()`.

So `await backgroundFetch(...)` stays pending, `Translator.tsx`'s `try/catch/finally` never runs, `stopLoading()` is never called, and the spinner never stops.

```
network failure
  -> background: postMessage({ error }) + port.disconnect()
  -> content:    onMessage sees error -> controller.error() -> return   (no reject)
  -> content:    onDisconnect        -> controller.close()              (no reject)
  -> await backgroundFetch(...) pending forever
```

A second, smaller leak: `fetchWithStream` returns without disconnecting when a response has no body, so the port and the stream stay open for a request that has already finished.

## Change

- Rename `resolved` to `settled` and treat it as "the promise has been settled", not "resolve has been called".
- Reject from the `{ error }` branch when the promise has not been settled yet, before erroring the stream. A caller that already has the `Response` is unaffected — the error still surfaces on the stream.
- Reject from `onDisconnect` when nothing settled the promise: `AbortError` if the signal was aborted, otherwise an error saying the connection closed before any response.
- Disconnect the port in the body-less response branch of `fetchWithStream`.

No behaviour changes on the success path.

## Tests

New `src/common/background/fetch.spec.ts` mocks the `browser.runtime.connect` port and covers:

- an `{ error }` message before any data → rejects with that error
- a bare disconnect with no message → rejects
- an already-aborted signal → rejects with `AbortError`
- an abort mid-flight → rejects with `AbortError`
- a normal two-chunk stream → resolves, `text()` reads the whole body
- an error arriving after `resolve()` → the promise stays resolved and the error surfaces on the stream

The first, second and fourth cases hang (time out) without this change.

## Verification

```
pnpm lint            # clean
pnpm test            # 10 files, 69 tests passing
npx tsc --noEmit     # clean
npx vite build -c vite.config.chromium.ts   # builds
```

## Platform coverage

Every target that routes fetch through the background port is affected: **Chrome**, **Firefox** and the **Tauri** build all go through `src/common/background/fetch.ts`. The `fetchWithStream` change is browser-extension only.
