### PR TITLE
fix: submit on keydown so an IME Enter is not swallowed

### DIFF
--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -1306,6 +1306,11 @@ function InnerTranslator(props: IInnerTranslatorProps) {
         async (selectedWord: string, signal: AbortSignal) => {
             if (skipNextTranslateRef.current) {
                 skipNextTranslateRef.current = false
+                // The effect cleanup aborts the previous run, and the aborted
+                // run returns before its finally clears the loading state - it
+                // relies on this run taking the state over. A bail out here
+                // must therefore clear it, or the spinner never stops.
+                stopLoading()
                 return
             }
             translationIDRef.current += 1
@@ -1315,6 +1320,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
             const translationID = translationIDRef.current
             const { text, sourceLang, targetLang, action } = translateDeps
             if (!text || !sourceLang || !targetLang || !action) {
+                stopLoading()
                 return
             }
             setShowWordbookButtons(false)
@@ -2095,32 +2101,44 @@ function InnerTranslator(props: IInnerTranslatorProps) {
             skipNextTranslateRef.current = false
             let action = activateAction
             if (!action) {
-                action = actions?.find((action) => action.mode === 'translate')
-                setActivateAction(action)
+                // The built-in translate action can be renamed or deleted, and
+                // on a cold start the action list may not have loaded yet.
+                action = actions?.find((a) => a.mode === 'translate') ?? actions?.[0]
+                if (action) {
+                    setActivateAction(action)
+                }
             }
-            const text = editorRef.current?.value ?? ''
-            if (action) {
-                getTranslateDeps(text, action)
-                    .then((v) => {
-                        // translateText compares deps deeply, so resubmitting
-                        // unchanged content would not retrigger it; bump the
-                        // translation flag (same mechanism as the Retry button)
-                        // so an explicit submit always runs.
-                        const unchanged = JSON.stringify(translateDepsRef.current) === JSON.stringify(v)
-                        setTranslateDeps(v)
-                        if (unchanged) {
-                            forceTranslate()
-                        }
-                    })
-                    .catch((error) => {
-                        // A rejected language detection used to kill the submit
-                        // silently; surface it instead.
-                        console.error('submit failed:', error)
-                        toast(String(error), { duration: 5000, icon: '❌' })
-                    })
+            const text = editorRef.current?.value ?? editableText
+            if (!action) {
+                // Bailing out here used to be completely silent.
+                toast(t('No available action'), { duration: 5000, icon: '❌' })
+                return
             }
+            const submittedAction = action
+            getTranslateDeps(text, submittedAction)
+                .then((v) => {
+                    // getTranslateDeps carries the previous action over, which
+                    // is empty on the very first submit; without this the
+                    // translate effect bails on its missing-deps guard.
+                    const deps = { ...v, action: submittedAction }
+                    // translateText compares deps deeply, so resubmitting
+                    // unchanged content would not retrigger it; bump the
+                    // translation flag (same mechanism as the Retry button)
+                    // so an explicit submit always runs.
+                    const unchanged = JSON.stringify(translateDepsRef.current) === JSON.stringify(deps)
+                    setTranslateDeps(deps)
+                    if (unchanged) {
+                        forceTranslate()
+                    }
+                })
+                .catch((error) => {
+                    // A rejected language detection used to kill the submit
+                    // silently; surface it instead.
+                    console.error('submit failed:', error)
+                    toast(String(error), { duration: 5000, icon: '❌' })
+                })
         },
-        [actions, activateAction, getTranslateDeps]
+        [actions, activateAction, editableText, getTranslateDeps, t]
     )
 
     const { data: promotions, mutate: refetchPromotions } = useSWR<IPromotionResponse>(
@@ -2583,6 +2601,20 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                                             onChange={(e) => setEditableText(e.target.value)}
                                             onKeyDown={(e) => {
                                                 e.stopPropagation()
+                                                if (e.key !== 'Enter' || e.shiftKey) {
+                                                    return
+                                                }
+                                                // Chrome does not fire keypress
+                                                // while an IME is composing, so
+                                                // submitting from keypress made
+                                                // the Enter that commits a
+                                                // candidate disappear; submit
+                                                // from keydown and skip the
+                                                // composing Enter instead.
+                                                if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) {
+                                                    return
+                                                }
+                                                handleSubmit(e)
                                             }}
                                             onKeyUp={(e) => {
                                                 e.stopPropagation()
@@ -2590,7 +2622,10 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                                             onKeyPress={(e) => {
                                                 e.stopPropagation()
                                                 if (e.key === 'Enter' && !e.shiftKey) {
-                                                    handleSubmit(e)
+                                                    // Submitting already
+                                                    // happened on keydown; keep
+                                                    // the newline out.
+                                                    e.preventDefault()
                                                 }
                                             }}
                                         />

--- a/src/common/i18n/locales/en/translation.json
+++ b/src/common/i18n/locales/en/translation.json
@@ -104,6 +104,7 @@
     "Update": "Update",
     "Action": "Action",
     "All Actions": "All actions",
+    "No available action": "No available action",
     "Action Manager": "Action Manager",
     "Clear All History?": "Clear all history?",
     "Clear History": "Clear history",

--- a/src/common/i18n/locales/zh-Hans/translation.json
+++ b/src/common/i18n/locales/zh-Hans/translation.json
@@ -104,6 +104,7 @@
     "Update": "更新",
     "Action": "动作",
     "All Actions": "全部动作",
+    "No available action": "没有可用的动作",
     "Action Manager": "动作管理器",
     "Clear All History?": "确认清空全部历史记录？",
     "Clear History": "清空历史记录",

--- a/src/common/i18n/locales/zh-Hant/translation.json
+++ b/src/common/i18n/locales/zh-Hant/translation.json
@@ -104,6 +104,7 @@
     "Update": "更新",
     "Action": "動作",
     "All Actions": "全部動作",
+    "No available action": "沒有可用的動作",
     "Action Manager": "動作管理員",
     "Clear All History?": "確認清除所有歷史記錄？",
     "Clear History": "清除歷史記錄",


### PR DESCRIPTION
## Problem

Three separate ways the translator silently does nothing. They are grouped here because all three are "the user acted and the UI gave no feedback"; happy to split if you would rather review them apart.

### 1. Enter is swallowed by an IME

Submit is bound to `onKeyPress`:

```tsx
onKeyPress={(e) => {
    e.stopPropagation()
    if (e.key === 'Enter' && !e.shiftKey) {
        handleSubmit(e)
    }
}}
```

Chrome does not dispatch `keypress` while an IME is composing (`keyCode === 229`). With a pinyin / kana / hangul IME, the Enter that commits the candidate produces no `keypress` at all, so that keystroke is lost and the text has to be submitted with a second Enter. There is no `isComposing` check anywhere in the repo.

### 2. `handleSubmit` bails without a word when no action resolves

```tsx
let action = activateAction
if (!action) {
    action = actions?.find((action) => action.mode === 'translate')
    setActivateAction(action)
}
const text = editorRef.current?.value ?? ''
if (action) { getTranslateDeps(text, action).then(...) }
// no else - submit does nothing at all
```

`action` is `undefined` when `actions` has not finished loading from IndexedDB yet, or when the built-in `mode === 'translate'` action has been renamed or deleted. Nothing is shown either way.

There is a second bail-out on the same path: `getTranslateDeps` returns `{ ...translateDepsRef.current, sourceLang, targetLang, text }`, i.e. it carries the *previous* `action` over. On the first submit that is empty, so the translate effect hits its `if (!text || !sourceLang || !targetLang || !action) return` guard and the submit disappears.

### 3. Two early returns leave the loading state stuck on

The translate effect's cleanup aborts the in-flight run, and the aborted run returns from its `catch` before the `finally` calls `stopLoading()` — by design, because the next run is expected to take the loading state over. But the next run can bail immediately, and neither bail-out clears it:

- the `skipNextTranslateRef` guard used by history restore
- `if (!text || !sourceLang || !targetLang || !action) return`, reached by switching the source/target language or clearing the OCR text

`isLoading` then stays `true` and the UI sits on "Translating…" with no request running.

## Change

- Move submit to `onKeyDown` and skip the composing Enter (`e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229`). `onKeyPress` keeps `stopPropagation()` and now only calls `preventDefault()` on Enter so no newline is inserted. Shift+Enter is untouched.
- Fall back to `actions?.[0]` when there is no `mode === 'translate'` action, and show a toast instead of returning silently when there is no action at all. New i18n key `No available action` (en / zh-Hans / zh-Hant; other locales fall back to English).
- Pass the submitted action explicitly into the deps (`{ ...v, action: submittedAction }`) so the first submit is not eaten by the missing-deps guard.
- Fall back to the `editableText` state when `editorRef.current` is not mounted.
- Call `stopLoading()` in both early returns of `translateText`. Semantically these branches mean "this run does not translate", so leaving a spinner up is wrong regardless.

## Verification

```
pnpm lint            # clean
pnpm test            # 9 files, 63 tests passing
npx tsc --noEmit     # clean
npx vite build -c vite.config.chromium.ts   # builds
```

The IME analysis is from the Chrome `keypress`/composition behaviour and the absence of any `isComposing` handling in the tree — worth a check with an IME on your side before merging. The other two are reachable purely from the code paths above.

No automated test is included: `Translator.tsx` has no test harness today and standing one up for this component is a much larger change than the fix. Let me know if you would like it split out.

## Platform coverage

`src/common/components/Translator.tsx` is shared, so this affects **Chrome**, **Firefox** and **Tauri**.
