### PR TITLE
fix: commit the model that was clicked in the model combobox

### DIFF
--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -69,6 +69,7 @@ import { usePromotionNeverDisplay } from '../hooks/usePromotionNeverDisplay'
 import { Textarea } from 'baseui-sd/textarea'
 import { ProxyTester } from './ProxyTester'
 import { CUSTOM_MODEL_ID } from '../constants'
+import { filterModelOptions } from './model-option-filter'
 import { isMacOS } from '../utils'
 import NumberInput from './NumberInput'
 import { DurationPicker } from './DurationPicker'
@@ -879,6 +880,17 @@ export function APIModelSelector({
         userEditedRef.current = false
     }, [currentProvider, provider])
 
+    // Filtering has to be driven by what the user typed, never by the committed
+    // value. Deriving it from the value makes the option list change as a
+    // *result* of picking an option, while baseui still holds the index into
+    // the list that was on screen when the click happened - it then resolves
+    // that stale index against the new list and both shows and commits a
+    // different model than the one clicked.
+    const [query, setQuery] = useState('')
+    useEffect(() => {
+        setQuery('')
+    }, [currentProvider, provider])
+
     useEffect(() => {
         if (provider !== currentProvider || options.length === 0) {
             return
@@ -913,26 +925,18 @@ export function APIModelSelector({
                     <Combobox
                         size='compact'
                         value={value ?? ''}
-                        onChange={(nextValue) => {
+                        onChange={(nextValue, option) => {
                             userEditedRef.current = true
+                            // baseui passes the option only when one was picked
+                            // from the listbox; a null option means the user
+                            // typed, which is the only thing that may refilter.
+                            if (!option) {
+                                setQuery(String(nextValue ?? ''))
+                            }
                             onChange?.(nextValue as APIModel)
                         }}
                         onBlur={onBlur}
-                        options={(() => {
-                            const query = (value ?? '').toLowerCase()
-                            if (!query) {
-                                return options
-                            }
-                            const matched = options.filter(
-                                (option) =>
-                                    option.id.toLowerCase().includes(query) || option.name.toLowerCase().includes(query)
-                            )
-                            const exactMatch = options.some((option) => option.id.toLowerCase() === query)
-                            // A picked model or a free-typed name that matches
-                            // nothing should still let the user browse the
-                            // full list when reopening the dropdown.
-                            return matched.length > 0 && !exactMatch ? matched : options
-                        })()}
+                        options={filterModelOptions(options, query)}
                         mapOptionToString={(option: APIModelOption) => option.id}
                         mapOptionToNode={({ option }: { isSelected: boolean; option: APIModelOption }) => (
                             <div

--- a/src/common/components/model-option-filter.spec.tsx
+++ b/src/common/components/model-option-filter.spec.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { Provider as StyletronProvider } from 'styletron-react'
+import { Client as Styletron } from 'styletron-engine-atomic'
+import { BaseProvider, LightTheme } from 'baseui-sd'
+import { Combobox } from 'baseui-sd/combobox'
+import { filterModelOptions } from './model-option-filter'
+
+interface Option {
+    id: string
+    name: string
+}
+
+// Shaped like an OpenRouter listing: the models a user searches for sit far
+// down a list of several hundred.
+const options: Option[] = [
+    ...Array.from({ length: 40 }, (_, i) => ({ id: `vendor/model-${i}`, name: `Model ${i}` })),
+    { id: 'bytedance-seed/seed-2-1-turbo', name: 'Seed 2.1 Turbo' },
+    { id: 'bytedance-seed/seed-2.0-code', name: 'Seed 2.0 Code' },
+    { id: 'bytedance-seed/seed-2.0-lite', name: 'Seed 2.0 Lite' },
+]
+
+describe('filterModelOptions', () => {
+    it('returns everything for an empty query', () => {
+        expect(filterModelOptions(options, '')).toHaveLength(options.length)
+        expect(filterModelOptions(options, '   ')).toHaveLength(options.length)
+    })
+
+    it('matches on both id and display name, case insensitively', () => {
+        expect(filterModelOptions(options, 'seed').map((o) => o.id)).toEqual([
+            'bytedance-seed/seed-2-1-turbo',
+            'bytedance-seed/seed-2.0-code',
+            'bytedance-seed/seed-2.0-lite',
+        ])
+        expect(filterModelOptions(options, 'SEED 2.0 Lite').map((o) => o.id)).toEqual(['bytedance-seed/seed-2.0-lite'])
+    })
+
+    it('falls back to the full list when nothing matches', () => {
+        expect(filterModelOptions(options, 'no-such-model')).toHaveLength(options.length)
+    })
+})
+
+// APIModelSelector lives in Settings.tsx, which cannot be imported from a test
+// (the module pulls in the whole settings tree and never settles). This mirrors
+// the wiring it uses so the regression is covered against the real combobox.
+function ModelCombobox({ onCommit }: { onCommit: (value: string) => void }) {
+    const [value, setValue] = useState('vendor/model-0')
+    const [query, setQuery] = useState('')
+    return (
+        <Combobox
+            value={value}
+            onChange={(nextValue: string, option: Option | null) => {
+                // Only typing may refilter; picking an option must leave the
+                // list - and therefore the combobox's index into it - alone.
+                if (!option) {
+                    setQuery(String(nextValue ?? ''))
+                }
+                setValue(nextValue)
+                onCommit(nextValue)
+            }}
+            options={filterModelOptions(options, query)}
+            mapOptionToString={(option: Option) => option.id}
+        />
+    )
+}
+
+function typeInto(input: HTMLInputElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+    setter.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+describe('model combobox selection', () => {
+    it('commits and keeps showing the model that was clicked in a filtered list', async () => {
+        const container = document.createElement('div')
+        document.body.appendChild(container)
+        const onCommit = vi.fn()
+
+        await act(async () => {
+            createRoot(container).render(
+                <StyletronProvider value={new Styletron()}>
+                    <BaseProvider theme={LightTheme}>
+                        <ModelCombobox onCommit={onCommit} />
+                    </BaseProvider>
+                </StyletronProvider>
+            )
+        })
+
+        const input = container.querySelector('input') as HTMLInputElement
+
+        await act(async () => typeInto(input, 'seed'))
+        const shown = Array.from(container.querySelectorAll('[role="option"]'))
+        expect(shown).toHaveLength(3)
+
+        await act(async () => {
+            shown[2].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        })
+
+        expect(onCommit).toHaveBeenLastCalledWith('bytedance-seed/seed-2.0-lite')
+        // Filtering off the committed value used to widen the list here, and
+        // the stale index then resolved to an unrelated model.
+        expect(input.value).toBe('bytedance-seed/seed-2.0-lite')
+
+        // A following Enter must not commit a different model either.
+        await act(async () => {
+            input.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        })
+        await act(async () => {
+            input.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter', keyCode: 13 }))
+        })
+        expect(onCommit).toHaveBeenLastCalledWith('bytedance-seed/seed-2.0-lite')
+    })
+})

--- a/src/common/components/model-option-filter.ts
+++ b/src/common/components/model-option-filter.ts
@@ -1,0 +1,27 @@
+export interface FilterableModelOption {
+    id: string
+    name: string
+}
+
+/**
+ * Narrows the model list by what the user typed.
+ *
+ * The query must be the user's typed text, never the committed model id.
+ * Deriving it from the committed value makes the option list change as a
+ * *result* of picking an option, while the combobox still holds the index into
+ * the list that was on screen when the click happened; it then resolves that
+ * stale index against the new list and both displays and commits a different
+ * model than the one that was clicked.
+ */
+export function filterModelOptions<T extends FilterableModelOption>(options: T[], query: string): T[] {
+    const q = query.trim().toLowerCase()
+    if (!q) {
+        return options
+    }
+    const matched = options.filter(
+        (option) => option.id.toLowerCase().includes(q) || option.name.toLowerCase().includes(q)
+    )
+    // A free-typed name that matches nothing should still let the user browse
+    // the full list rather than face an empty dropdown.
+    return matched.length > 0 ? matched : options
+}


### PR DESCRIPTION
## Problem

Picking a model from the model combobox can save a **different model** than the one clicked. Reported by a user on OpenRouter, whose listing currently returns 419 models.

`APIModelSelector` filters its option list with the **committed value**:

```tsx
const query = (value ?? '').toLowerCase()
if (!query) return options
const matched = options.filter((o) => o.id.toLowerCase().includes(query) || o.name.toLowerCase().includes(query))
const exactMatch = options.some((o) => o.id.toLowerCase() === query)
return matched.length > 0 && !exactMatch ? matched : options
```

So the list changes *as a result of* picking an option: the value becomes a full model id, `exactMatch` flips to true, and the list widens back to every model. baseui still holds the selection index into the list that was on screen when the click landed, and its autocomplete effect (on by default) resolves that index against the new list:

```js
// baseui-sd/combobox/combobox.js
React.useEffect(() => {
    ...
    if (autocomplete) {
        const selectedOption = options[selectionIndex]
        if (selectedOption) setTempValue(mapOptionToString(selectedOption))
    }
}, [options, selectionIndex])
```

The narrower the filter, the further off the result. Typing `seed` against an OpenRouter listing narrows 419 models to 3; clicking the third one puts the **43rd model of the full list** in the input.

It does not self-correct. Blur does not clear it — the effect rewrites `tempValue` — and a following Enter commits `options[selectionIndex]` from the wide list, so the wrong model is what actually gets saved.

Observed sequence:

```
click "bytedance-seed/seed-2.0-lite" in the filtered list
  -> onChange fires with bytedance-seed/seed-2.0-lite   (correct)
  -> input displays vendor/model-2                      (wrong)
  -> blur                                               (still wrong)
  -> Enter commits vendor/model-2                       (wrong model saved)
```

## Change

Drive the filtering from the user's typed text instead of the committed value. baseui passes the picked option as the second `onChange` argument and `null` when the user typed, so only typing refilters; picking leaves the list — and the index into it — untouched.

The `exactMatch` special case goes away with it. It existed to widen the list back after the value collapsed it onto a single model; with a typed query the list never collapses, so there is nothing to widen back. Reopening the dropdown after a pick still shows everything, which is what that branch was for.

The filter moves to `model-option-filter.ts` so it can be tested — `Settings.tsx` cannot be imported from a test, the module pulls in the whole settings tree and never settles (I let it run 300s).

## Tests

New `src/common/components/model-option-filter.spec.tsx`:

- `filterModelOptions` unit cases: empty/whitespace query, id and name matching (case-insensitive), and the no-match fallback to the full list.
- A selection test driving the **real** baseui `Combobox` in jsdom over a 43-model listing: type `seed`, assert the list narrows to 3, click the third, then assert the committed value, the displayed value, and the value after a following Enter are all `bytedance-seed/seed-2.0-lite`.

The selection test fails against the old filtering rule with exactly the reported symptom:

```
AssertionError: expected 'vendor/model-2' to be 'bytedance-seed/seed-2.0-lite'
```

The test harness mirrors `APIModelSelector`'s combobox wiring rather than importing it, for the reason above. If you would rather have the component itself under test, I am happy to pull `APIModelSelector` out of `Settings.tsx` into its own module in a follow-up.

## Verification

```
pnpm lint            # clean
pnpm test            # 11 files, 73 tests passing
npx tsc --noEmit     # clean
npx vite build -c vite.config.chromium.ts   # builds
```

## Platform coverage

`Settings.tsx` is shared, so this affects **Chrome**, **Firefox** and **Tauri**. It hits any provider with a long model list hardest — OpenRouter most of all — but the stale-index path applies to every provider whose list is long enough to filter.
