### PR TITLE
fix: keep last streamed segment when content and finish_reason share a chunk (#1810)

### DIFF
--- a/src/common/engines/abstract-openai.spec.ts
+++ b/src/common/engines/abstract-openai.spec.ts
@@ -132,6 +132,31 @@ describe('AbstractOpenAI', () => {
         expect(onFinished).toHaveBeenCalledWith('stop')
     })
 
+    it('emits the final text segment when content and finish_reason arrive together in one chunk', async () => {
+        const engine = new TestOpenAIEngine('gpt-4')
+        const { req, onMessage, onFinished } = createMessageRequest()
+
+        vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+            expect(input).toBe('https://api.openai.com/v1/chat/completions')
+
+            // OpenRouter forwarding Gemini emits the last text segment together
+            // with finish_reason in the same SSE chunk instead of sending an
+            // empty delta on a trailing chunk like the OpenAI API does. The
+            // content must still be emitted and must not be dropped.
+            await options.onMessage(
+                JSON.stringify({
+                    // eslint-disable-next-line camelcase
+                    choices: [{ delta: { content: '最后一段', role: 'assistant' }, finish_reason: 'stop' }],
+                })
+            )
+        })
+
+        await engine.sendMessage(req)
+
+        expect(onMessage).toHaveBeenCalledWith({ content: '最后一段', role: 'assistant' })
+        expect(onFinished).toHaveBeenCalledWith('stop')
+    })
+
     it('does not send reasoning_effort for GPT-5 code models', async () => {
         const engine = new TestOpenAIEngine('gpt-5-code')
         const { req } = createMessageRequest()

--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -336,7 +336,7 @@ export abstract class AbstractOpenAI extends AbstractEngine {
                 if (!choices || choices.length === 0) {
                     return
                 }
-                                const { finish_reason: finishReason, delta } = choices[0]
+                const { finish_reason: finishReason, delta } = choices[0]
 
                 // OpenAI ends a stream with an empty delta plus finish_reason,
                 // but some proxies (e.g. OpenRouter -> Gemini) send the final

--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -338,11 +338,10 @@ export abstract class AbstractOpenAI extends AbstractEngine {
                 }
                                 const { finish_reason: finishReason, delta } = choices[0]
 
-                // Some providers (e.g. OpenRouter forwarding Gemini) emit the
-                // final text segment together with finish_reason in the same
-                // chunk, instead of sending an empty delta on the last chunk
-                // like the OpenAI API does. Emit the content first so the last
-                // segment is not dropped when finish_reason is present.
+                // OpenAI ends a stream with an empty delta plus finish_reason,
+                // but some proxies (e.g. OpenRouter -> Gemini) send the final
+                // text segment together with finish_reason in the same chunk.
+                // Emit the content first so the last segment is never dropped.
                 if (isChatAPI) {
                     const { content = '', role } = delta ?? {}
                     if (content) {

--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -336,25 +336,29 @@ export abstract class AbstractOpenAI extends AbstractEngine {
                 if (!choices || choices.length === 0) {
                     return
                 }
-                const { finish_reason: finishReason } = choices[0]
+                                const { finish_reason: finishReason, delta } = choices[0]
+
+                // Some providers (e.g. OpenRouter forwarding Gemini) emit the
+                // final text segment together with finish_reason in the same
+                // chunk, instead of sending an empty delta on the last chunk
+                // like the OpenAI API does. Emit the content first so the last
+                // segment is not dropped when finish_reason is present.
+                if (isChatAPI) {
+                    const { content = '', role } = delta ?? {}
+                    if (content) {
+                        await req.onMessage({ content, role })
+                    }
+                } else {
+                    const text = choices[0].text
+                    if (text) {
+                        await req.onMessage({ content: text, role: '' })
+                    }
+                }
+
                 if (finishReason) {
                     req.onFinished(finishReason)
                     finished = true
                     return
-                }
-
-                let targetTxt = ''
-                if (!isChatAPI) {
-                    // It's used for Azure OpenAI Service's legacy parameters.
-                    targetTxt = choices[0].text
-
-                    await req.onMessage({ content: targetTxt, role: '' })
-                } else {
-                    const { content = '', role } = choices[0].delta
-
-                    targetTxt = content
-
-                    await req.onMessage({ content: targetTxt, role })
                 }
             },
             onError: (err) => {


### PR DESCRIPTION
## Summary

Fixes #1810 — OpenRouter-fronted Gemini streams the final text segment in the **same** SSE chunk as `finish_reason`, unlike the OpenAI API which sends an empty delta on a trailing chunk. The previous parser returned early on `finish_reason`, discarding that last segment — so the tail of every Gemini response (via OpenRouter) was silently dropped.

## Changes

- `src/common/engines/abstract-openai.ts`: emit `delta.content` (chat completions) or `text` (legacy) **before** checking `finish_reason`, so the final segment is no longer dropped when both arrive together.
- `src/common/engines/abstract-openai.spec.ts`: add a regression test that feeds a single chunk carrying both `content` and `finish_reason` and asserts the content is delivered.

## Verification

The regression test reproduces the OpenRouter/Gemini framing and is covered by the CI `vitest` run.