### PR TITLE
fix(cerebras): keep last streamed segment when content and finish_reason share a chunk (#1810)

### DIFF
--- a/src/common/engines/cerebras.spec.ts
+++ b/src/common/engines/cerebras.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Cerebras } from './cerebras'
 import { IMessageRequest } from './interfaces'
-import { fetchSSE, getSettings } from '../utils'
+import { fetchSSE } from '../utils'
 
 vi.mock('../utils', () => {
     return {

--- a/src/common/engines/cerebras.spec.ts
+++ b/src/common/engines/cerebras.spec.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Cerebras } from './cerebras'
+import { IMessageRequest } from './interfaces'
+import { fetchSSE, getSettings } from '../utils'
+
+vi.mock('../utils', () => {
+    return {
+        fetchSSE: vi.fn(),
+        getSettings: vi.fn().mockResolvedValue({
+            cerebrasAPIKey: 'test-api-key',
+            cerebrasAPIModel: 'test-model',
+            noModelsAPISupport: false,
+        }),
+    }
+})
+
+interface MockFetchSSEOptions {
+    body?: BodyInit | null
+    onMessage: (data: string) => Promise<void>
+    onError?: (err: unknown) => void
+}
+
+function createMessageRequest() {
+    const onMessage = vi.fn().mockResolvedValue(undefined)
+    const onError = vi.fn()
+    const onFinished = vi.fn()
+    const req: IMessageRequest = {
+        rolePrompt: 'You are a translator',
+        commandPrompt: 'Translate hello to Chinese',
+        onMessage,
+        onError,
+        onFinished,
+        signal: new AbortController().signal,
+    }
+    return { req, onMessage, onError, onFinished }
+}
+
+describe('Cerebras', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('emits streamed content and finishes on a trailing chunk', async () => {
+        const engine = new Cerebras()
+        const { req, onMessage, onFinished } = createMessageRequest()
+
+        vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+            expect(input).toBe('https://api.cerebras.ai/v1/chat/completions')
+            expect(typeof options.body).toBe('string')
+            const payload = JSON.parse(options.body as string)
+            expect(payload.model).toBe('test-model')
+            expect(payload.stream).toBe(true)
+
+            await options.onMessage(
+                JSON.stringify({
+                    choices: [{ delta: { content: '你好', role: 'assistant' } }],
+                })
+            )
+            await options.onMessage(
+                JSON.stringify({
+                    // eslint-disable-next-line camelcase
+                    choices: [{ delta: {}, finish_reason: 'stop' }],
+                })
+            )
+        })
+
+        await engine.sendMessage(req)
+
+        expect(onMessage).toHaveBeenCalledWith({ content: '你好', role: 'assistant' })
+        expect(onFinished).toHaveBeenCalledWith('stop')
+    })
+
+    it('emits the final text segment when content and finish_reason arrive together in one chunk', async () => {
+        const engine = new Cerebras()
+        const { req, onMessage, onFinished } = createMessageRequest()
+
+        vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+            expect(input).toBe('https://api.cerebras.ai/v1/chat/completions')
+
+            // OpenRouter forwarding Cerebras emits the last text segment
+            // together with finish_reason in the same SSE chunk instead of
+            // sending an empty delta on a trailing chunk like the OpenAI API
+            // does. The content must still be emitted and must not be dropped.
+            await options.onMessage(
+                JSON.stringify({
+                    // eslint-disable-next-line camelcase
+                    choices: [{ delta: { content: '最后一段', role: 'assistant' }, finish_reason: 'stop' }],
+                })
+            )
+        })
+
+        await engine.sendMessage(req)
+
+        expect(onMessage).toHaveBeenCalledWith({ content: '最后一段', role: 'assistant' })
+        expect(onFinished).toHaveBeenCalledWith('stop')
+    })
+})

--- a/src/common/engines/cerebras.ts
+++ b/src/common/engines/cerebras.ts
@@ -96,24 +96,24 @@ export class Cerebras extends AbstractEngine {
                 if (!choices || choices.length === 0) {
                     return
                 }
-                                const { finish_reason: finishReason, delta } = choices[0]
+                const { finish_reason: finishReason, delta } = choices[0]
 
-                // Some OpenAI-compatible providers (e.g. Cerebras behind
-                // OpenRouter) emit the final text segment together with
-                // finish_reason in the same SSE chunk instead of sending an
-                // empty delta on a trailing chunk like the OpenAI API does.
-                // Emit the content before handling finish_reason so the last
-                // segment is not dropped.
-                const { content = '', role } = delta ?? {}
-                if (content) {
-                    await req.onMessage({ content, role })
-                }
+// Some OpenAI-compatible providers (e.g. Cerebras behind
+// OpenRouter) emit the final text segment together with
+// finish_reason in the same SSE chunk instead of sending an
+// empty delta on a trailing chunk like the OpenAI API does.
+// Emit the content before handling finish_reason so the last
+// segment is not dropped.
+const { content = '', role } = delta ?? {}
+if (content) {
+    await req.onMessage({ content, role })
+}
 
-                if (finishReason) {
-                    req.onFinished(finishReason)
-                    finished = true
-                    return
-                }
+if (finishReason) {
+    req.onFinished(finishReason)
+    finished = true
+    return
+}
             },
             onError: (err) => {
                 if (err instanceof Error) {

--- a/src/common/engines/cerebras.ts
+++ b/src/common/engines/cerebras.ts
@@ -98,22 +98,22 @@ export class Cerebras extends AbstractEngine {
                 }
                 const { finish_reason: finishReason, delta } = choices[0]
 
-// Some OpenAI-compatible providers (e.g. Cerebras behind
-// OpenRouter) emit the final text segment together with
-// finish_reason in the same SSE chunk instead of sending an
-// empty delta on a trailing chunk like the OpenAI API does.
-// Emit the content before handling finish_reason so the last
-// segment is not dropped.
-const { content = '', role } = delta ?? {}
-if (content) {
-    await req.onMessage({ content, role })
-}
+                // Some OpenAI-compatible providers (e.g. Cerebras behind
+                // OpenRouter) emit the final text segment together with
+                // finish_reason in the same SSE chunk instead of sending an
+                // empty delta on a trailing chunk like the OpenAI API does.
+                // Emit the content before handling finish_reason so the last
+                // segment is not dropped.
+                const { content = '', role } = delta ?? {}
+                if (content) {
+                    await req.onMessage({ content, role })
+                }
 
-if (finishReason) {
-    req.onFinished(finishReason)
-    finished = true
-    return
-}
+                if (finishReason) {
+                    req.onFinished(finishReason)
+                    finished = true
+                    return
+                }
             },
             onError: (err) => {
                 if (err instanceof Error) {

--- a/src/common/engines/cerebras.ts
+++ b/src/common/engines/cerebras.ts
@@ -96,20 +96,24 @@ export class Cerebras extends AbstractEngine {
                 if (!choices || choices.length === 0) {
                     return
                 }
-                const { finish_reason: finishReason } = choices[0]
+                                const { finish_reason: finishReason, delta } = choices[0]
+
+                // Some OpenAI-compatible providers (e.g. Cerebras behind
+                // OpenRouter) emit the final text segment together with
+                // finish_reason in the same SSE chunk instead of sending an
+                // empty delta on a trailing chunk like the OpenAI API does.
+                // Emit the content before handling finish_reason so the last
+                // segment is not dropped.
+                const { content = '', role } = delta ?? {}
+                if (content) {
+                    await req.onMessage({ content, role })
+                }
+
                 if (finishReason) {
                     req.onFinished(finishReason)
                     finished = true
                     return
                 }
-
-                let targetTxt = ''
-
-                const { content = '', role } = choices[0].delta
-
-                targetTxt = content
-
-                await req.onMessage({ content: targetTxt, role })
             },
             onError: (err) => {
                 if (err instanceof Error) {


### PR DESCRIPTION
## Summary
Fixes the same streaming bug as #1810, this time in the `Cerebras` engine.

OpenAI-compatible providers that sit behind a proxy (e.g. OpenRouter forwarding Cerebras) emit the **final text segment together with `finish_reason` in the same SSE chunk**, instead of sending an empty `delta` on a trailing chunk like the native OpenAI API does. The previous code returned early as soon as `finish_reason` was seen, discarding the same chunk's `delta.content` — so the last segment of the translation was silently dropped.

## Change
- `src/common/engines/cerebras.ts`: emit `delta.content` (when present) **before** handling `finish_reason`, matching the fix already applied to `abstract-openai.ts` in #1921.
- `src/common/engines/cerebras.spec.ts`: new regression test asserting that a single chunk carrying both `content` and `finish_reason` still delivers the text and fires `onFinished('stop')`.

## Test plan
- `vitest` unit-test `src/common/engines/cerebras.spec.ts` (new regression test).
- Manual: translate with a Cerebras model via OpenRouter; the tail of the result is no longer truncated.

Relates to #1810.
