### PR TITLE
refactor(cerebras): extend AbstractOpenAI to de-duplicate streaming parser (#1810)

### DIFF
--- a/src/common/engines/abstract-openai.spec.ts
+++ b/src/common/engines/abstract-openai.spec.ts
@@ -132,6 +132,31 @@ describe('AbstractOpenAI', () => {
         expect(onFinished).toHaveBeenCalledWith('stop')
     })
 
+    it('emits the final text segment when content and finish_reason arrive together in one chunk', async () => {
+        const engine = new TestOpenAIEngine('gpt-4')
+        const { req, onMessage, onFinished } = createMessageRequest()
+
+        vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+            expect(input).toBe('https://api.openai.com/v1/chat/completions')
+
+            // OpenRouter forwarding Gemini emits the last text segment together
+            // with finish_reason in the same SSE chunk instead of sending an
+            // empty delta on a trailing chunk like the OpenAI API does. The
+            // content must still be emitted and must not be dropped.
+            await options.onMessage(
+                JSON.stringify({
+                    // eslint-disable-next-line camelcase
+                    choices: [{ delta: { content: '最后一段', role: 'assistant' }, finish_reason: 'stop' }],
+                })
+            )
+        })
+
+        await engine.sendMessage(req)
+
+        expect(onMessage).toHaveBeenCalledWith({ content: '最后一段', role: 'assistant' })
+        expect(onFinished).toHaveBeenCalledWith('stop')
+    })
+
     it('does not send reasoning_effort for GPT-5 code models', async () => {
         const engine = new TestOpenAIEngine('gpt-5-code')
         const { req } = createMessageRequest()

--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -336,7 +336,7 @@ export abstract class AbstractOpenAI extends AbstractEngine {
                 if (!choices || choices.length === 0) {
                     return
                 }
-                                const { finish_reason: finishReason, delta } = choices[0]
+                const { finish_reason: finishReason, delta } = choices[0]
 
                 // OpenAI ends a stream with an empty delta plus finish_reason,
                 // but some proxies (e.g. OpenRouter -> Gemini) send the final

--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -338,11 +338,10 @@ export abstract class AbstractOpenAI extends AbstractEngine {
                 }
                                 const { finish_reason: finishReason, delta } = choices[0]
 
-                // Some providers (e.g. OpenRouter forwarding Gemini) emit the
-                // final text segment together with finish_reason in the same
-                // chunk, instead of sending an empty delta on the last chunk
-                // like the OpenAI API does. Emit the content first so the last
-                // segment is not dropped when finish_reason is present.
+                // OpenAI ends a stream with an empty delta plus finish_reason,
+                // but some proxies (e.g. OpenRouter -> Gemini) send the final
+                // text segment together with finish_reason in the same chunk.
+                // Emit the content first so the last segment is never dropped.
                 if (isChatAPI) {
                     const { content = '', role } = delta ?? {}
                     if (content) {

--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -336,25 +336,29 @@ export abstract class AbstractOpenAI extends AbstractEngine {
                 if (!choices || choices.length === 0) {
                     return
                 }
-                const { finish_reason: finishReason } = choices[0]
+                                const { finish_reason: finishReason, delta } = choices[0]
+
+                // Some providers (e.g. OpenRouter forwarding Gemini) emit the
+                // final text segment together with finish_reason in the same
+                // chunk, instead of sending an empty delta on the last chunk
+                // like the OpenAI API does. Emit the content first so the last
+                // segment is not dropped when finish_reason is present.
+                if (isChatAPI) {
+                    const { content = '', role } = delta ?? {}
+                    if (content) {
+                        await req.onMessage({ content, role })
+                    }
+                } else {
+                    const text = choices[0].text
+                    if (text) {
+                        await req.onMessage({ content: text, role: '' })
+                    }
+                }
+
                 if (finishReason) {
                     req.onFinished(finishReason)
                     finished = true
                     return
-                }
-
-                let targetTxt = ''
-                if (!isChatAPI) {
-                    // It's used for Azure OpenAI Service's legacy parameters.
-                    targetTxt = choices[0].text
-
-                    await req.onMessage({ content: targetTxt, role: '' })
-                } else {
-                    const { content = '', role } = choices[0].delta
-
-                    targetTxt = content
-
-                    await req.onMessage({ content: targetTxt, role })
                 }
             },
             onError: (err) => {

--- a/src/common/engines/cerebras.spec.ts
+++ b/src/common/engines/cerebras.spec.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Cerebras } from './cerebras'
+import { IMessageRequest } from './interfaces'
+import { fetchSSE } from '../utils'
+
+vi.mock('../utils', () => {
+    return {
+        fetchSSE: vi.fn(),
+        getSettings: vi.fn().mockResolvedValue({
+            cerebrasAPIKey: 'test-api-key',
+            cerebrasAPIModel: 'test-model',
+            noModelsAPISupport: false,
+        }),
+    }
+})
+
+interface MockFetchSSEOptions {
+    body?: BodyInit | null
+    onMessage: (data: string) => Promise<void>
+    onError?: (err: unknown) => void
+}
+
+function createMessageRequest() {
+    const onMessage = vi.fn().mockResolvedValue(undefined)
+    const onError = vi.fn()
+    const onFinished = vi.fn()
+    const req: IMessageRequest = {
+        rolePrompt: 'You are a translator',
+        commandPrompt: 'Translate hello to Chinese',
+        onMessage,
+        onError,
+        onFinished,
+        signal: new AbortController().signal,
+    }
+    return { req, onMessage, onError, onFinished }
+}
+
+describe('Cerebras', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('emits streamed content and finishes on a trailing chunk', async () => {
+        const engine = new Cerebras()
+        const { req, onMessage, onFinished } = createMessageRequest()
+
+        vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+            expect(input).toBe('https://api.cerebras.ai/v1/chat/completions')
+            expect(typeof options.body).toBe('string')
+            const payload = JSON.parse(options.body as string)
+            expect(payload.model).toBe('test-model')
+            expect(payload.stream).toBe(true)
+
+            await options.onMessage(
+                JSON.stringify({
+                    choices: [{ delta: { content: '你好', role: 'assistant' } }],
+                })
+            )
+            await options.onMessage(
+                JSON.stringify({
+                    // eslint-disable-next-line camelcase
+                    choices: [{ delta: {}, finish_reason: 'stop' }],
+                })
+            )
+        })
+
+        await engine.sendMessage(req)
+
+        expect(onMessage).toHaveBeenCalledWith({ content: '你好', role: 'assistant' })
+        expect(onFinished).toHaveBeenCalledWith('stop')
+    })
+
+    it('emits the final text segment when content and finish_reason arrive together in one chunk', async () => {
+        const engine = new Cerebras()
+        const { req, onMessage, onFinished } = createMessageRequest()
+
+        vi.mocked(fetchSSE).mockImplementationOnce(async (input: string, options: MockFetchSSEOptions) => {
+            expect(input).toBe('https://api.cerebras.ai/v1/chat/completions')
+
+            // OpenRouter forwarding Cerebras emits the last text segment
+            // together with finish_reason in the same SSE chunk instead of
+            // sending an empty delta on a trailing chunk like the OpenAI API
+            // does. The content must still be emitted and must not be dropped.
+            await options.onMessage(
+                JSON.stringify({
+                    // eslint-disable-next-line camelcase
+                    choices: [{ delta: { content: '最后一段', role: 'assistant' }, finish_reason: 'stop' }],
+                })
+            )
+        })
+
+        await engine.sendMessage(req)
+
+        expect(onMessage).toHaveBeenCalledWith({ content: '最后一段', role: 'assistant' })
+        expect(onFinished).toHaveBeenCalledWith('stop')
+    })
+})

--- a/src/common/engines/cerebras.ts
+++ b/src/common/engines/cerebras.ts
@@ -1,150 +1,36 @@
-/* eslint-disable camelcase */
-import { getUniversalFetch } from '../universal-fetch'
-import { fetchSSE, getSettings } from '../utils'
-import { AbstractEngine } from './abstract-engine'
-import { IMessageRequest, IModel } from './interfaces'
+import { getSettings } from '../utils'
+import { AbstractOpenAI } from './abstract-openai'
 
-export class Cerebras extends AbstractEngine {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async listModels(apiKey: string | undefined): Promise<IModel[]> {
-        if (!apiKey) {
-            return []
-        }
-        const url = 'https://api.cerebras.ai/v1/models'
-        const fetcher = getUniversalFetch()
-        const resp = await fetcher(url, {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${apiKey}`,
-            },
-        })
-        if (!resp.ok) {
-            throw new Error(`Failed to fetch models: ${resp.statusText}`)
-        }
-        const data = await resp.json()
-        return (
-            data.data
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .map((item: any) => {
-                    return {
-                        id: item.id,
-                        name: item.id,
-                    }
-                })
-        )
-    }
-
-    async getModel(): Promise<string> {
+export class Cerebras extends AbstractOpenAI {
+    async getAPIModel(): Promise<string> {
         const settings = await getSettings()
         return settings.cerebrasAPIModel
     }
 
-    async sendMessage(req: IMessageRequest): Promise<void> {
+    async getAPIKey(): Promise<string> {
         const settings = await getSettings()
-        const apiKey = settings.cerebrasAPIKey
-        const model = req.modelOverride || (await this.getModel())
-        const url = 'https://api.cerebras.ai/v1/chat/completions'
-        const headers = {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'Authorization': `Bearer ${apiKey}`,
-        }
-        const messages = [
-            {
-                role: 'user',
-                content: req.rolePrompt ? req.rolePrompt + '\n\n' + req.commandPrompt : req.commandPrompt,
-            },
-        ]
-        const body = {
+        return settings.cerebrasAPIKey
+    }
+
+    async getAPIURL(): Promise<string> {
+        return 'https://api.cerebras.ai'
+    }
+
+    async getAPIURLPath(): Promise<string> {
+        return '/v1/chat/completions'
+    }
+
+    // The shared OpenAI base class omits temperature/top_p for non-GPT models,
+    // but Cerebras' endpoint expects them. Keep the original request shape so
+    // output determinism is preserved after de-duplicating sendMessage (#1810).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async getBaseRequestBody(modelParam?: string): Promise<Record<string, any>> {
+        const model = modelParam || (await this.getAPIModel())
+        return {
             model,
-            messages,
             temperature: 0,
             top_p: 1,
             stream: true,
         }
-        let finished = false // finished can be called twice because event.data is 1. "finish_reason":"stop"; 2. [DONE]
-        await fetchSSE(url, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify(body),
-            signal: req.signal,
-            onMessage: async (msg) => {
-                if (finished) return
-                let resp
-                try {
-                    resp = JSON.parse(msg)
-                    // eslint-disable-next-line no-empty, @typescript-eslint/no-explicit-any
-                } catch (e: any) {
-                    // avoid `Unexpected token 'D', "[DONE]" is not valid JSON`
-                    if (msg.trim() !== '[DONE]') {
-                        req.onError?.(e?.message ?? 'Cannot parse response JSON')
-                    }
-
-                    req.onFinished('stop')
-                    finished = true
-                    return
-                }
-
-                const { x_groq } = resp
-
-                if (x_groq && x_groq.error) {
-                    req.onError?.(x_groq.error)
-                }
-
-                const { choices } = resp
-                if (!choices || choices.length === 0) {
-                    return
-                }
-                const { finish_reason: finishReason } = choices[0]
-                if (finishReason) {
-                    req.onFinished(finishReason)
-                    finished = true
-                    return
-                }
-
-                let targetTxt = ''
-
-                const { content = '', role } = choices[0].delta
-
-                targetTxt = content
-
-                await req.onMessage({ content: targetTxt, role })
-            },
-            onError: (err) => {
-                if (err instanceof Error) {
-                    req.onError(err.message)
-                    return
-                }
-                if (typeof err === 'string') {
-                    req.onError(err)
-                    return
-                }
-                if (typeof err === 'object') {
-                    const { detail } = err
-                    if (detail) {
-                        req.onError(detail)
-                        return
-                    }
-                }
-                const { error } = err
-                if (error instanceof Error) {
-                    req.onError(error.message)
-                    return
-                }
-                if (typeof error === 'object') {
-                    const { message } = error
-                    if (message) {
-                        if (typeof message === 'string') {
-                            req.onError(message)
-                        } else {
-                            req.onError(JSON.stringify(message))
-                        }
-                        return
-                    }
-                }
-                req.onError('Unknown error')
-            },
-        })
     }
 }

--- a/src/common/engines/cerebras.ts
+++ b/src/common/engines/cerebras.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { getSettings } from '../utils'
 import { AbstractOpenAI } from './abstract-openai'
 


### PR DESCRIPTION
## Summary
Cerebras previously `extends AbstractEngine` and re-implemented the entire OpenAI-compatible streaming parser by hand. That copy diverged from `AbstractOpenAI` and independently reproduced the same last-segment-dropping bug as #1810 (fixed for the base class in #1921).

This change re-parents `Cerebras` onto `AbstractOpenAI` and deletes the duplicated `sendMessage` / `listModels` / `getModel`. Cerebras now inherits the single shared, already-fixed streaming parser, so this class of bug can no longer exist in two places.

## Behavior preservation
- `getBaseRequestBody` override keeps `temperature: 0, top_p: 1, stream: true` (the original request shape) because the shared base omits them for non-GPT models; this preserves output determinism.
- `getAPIURL()` -> `https://api.cerebras.ai` so both the chat and models endpoints resolve identically.
- `isChatAPI()` defaults to `true` and `shouldUseResponsesAPI()` returns `false` for the Cerebras endpoint, so the chat `delta.content` path (with the #1921 fix) is used.

## Test plan
- `cerebras.spec.ts` (ported from #1922) is kept and now exercises the *inherited* parser; both cases (trailing finish_reason chunk, and content + finish_reason in one chunk) pass.

## Notes
- Supersedes #1922 (the standalone Cerebras fix) — please merge #1921 first, then this PR, and close #1922.
- Built on top of #1921 so the inherited parser is already fixed (no regression window).